### PR TITLE
fix docker-compose deployment on app running on port 80

### DIFF
--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -84,4 +84,5 @@ services:
       - CLIENT_ID=my-client
       - CLIENT_REDIRECT_URI=http://localhost/sign-in-callback
       - CLIENT_LOGOUT_REDIRECT_URI=http://localhost/logout-callback
+      - ISSUER_HOST=localhost:9090
 


### PR DESCRIPTION
Interestingly the oidc-client-js didn't validate the port...