### PR TITLE
Switch to imagePullPolicy: IfNotPresent to ease local minikube dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ spec:
       containers:
       - name: oidc-mock-server
         image: docker.io/gridsuite/oidc-mock-server:latest
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 3000
         env:

--- a/k8s/base/balances-adjustment-server-deployment.yaml
+++ b/k8s/base/balances-adjustment-server-deployment.yaml
@@ -17,7 +17,7 @@ spec:
       containers:
         - name: balances-adjustment-server
           image: docker.io/gridsuite/balances-adjustment-server:latest
-          imagePullPolicy: Always
+          imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 80
           volumeMounts:

--- a/k8s/base/case-server-deployment.yaml
+++ b/k8s/base/case-server-deployment.yaml
@@ -17,7 +17,7 @@ spec:
       containers:
       - name: case-server
         image: docker.io/powsybl/case-server:latest
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 80
         volumeMounts:

--- a/k8s/base/case-validation-server-deployment.yaml
+++ b/k8s/base/case-validation-server-deployment.yaml
@@ -17,7 +17,7 @@ spec:
       containers:
       - name: case-validation-server
         image: docker.io/gridsuite/case-validation-server:latest
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 80
         volumeMounts:

--- a/k8s/base/cgmes-gl-server-deployment.yaml
+++ b/k8s/base/cgmes-gl-server-deployment.yaml
@@ -17,7 +17,7 @@ spec:
       containers:
       - name: cgmes-gl
         image: docker.io/powsybl/cgmes-gl-server:latest
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 80
         volumeMounts:

--- a/k8s/base/gateway-deployment.yaml
+++ b/k8s/base/gateway-deployment.yaml
@@ -17,7 +17,7 @@ spec:
       containers:
       - name: gateway
         image: docker.io/gridsuite/gateway:latest
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 80
         volumeMounts:

--- a/k8s/base/geo-data-server-deployment.yaml
+++ b/k8s/base/geo-data-server-deployment.yaml
@@ -17,7 +17,7 @@ spec:
       containers:
       - name: geo-data-server
         image: docker.io/powsybl/geo-data-server:latest
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 80
         volumeMounts:

--- a/k8s/base/loadflow-server-deployment.yaml
+++ b/k8s/base/loadflow-server-deployment.yaml
@@ -17,7 +17,7 @@ spec:
       containers:
       - name: loadflow-server
         image: docker.io/gridsuite/loadflow-server:latest
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 80
         volumeMounts:

--- a/k8s/base/network-conversion-server-deployment.yaml
+++ b/k8s/base/network-conversion-server-deployment.yaml
@@ -17,7 +17,7 @@ spec:
       containers:
       - name: network-conversion
         image: docker.io/powsybl/network-conversion-server:latest
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 80
         volumeMounts:

--- a/k8s/base/network-map-server-deployment.yaml
+++ b/k8s/base/network-map-server-deployment.yaml
@@ -17,7 +17,7 @@ spec:
       containers:
       - name: network-map
         image: docker.io/powsybl/network-map-server:latest
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 80
         volumeMounts:

--- a/k8s/base/network-modification-server-deployment.yaml
+++ b/k8s/base/network-modification-server-deployment.yaml
@@ -17,7 +17,7 @@ spec:
       containers:
       - name: network-modification-server
         image: docker.io/gridsuite/network-modification-server:latest
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 80
         volumeMounts:

--- a/k8s/base/network-store-server-deployment.yaml
+++ b/k8s/base/network-store-server-deployment.yaml
@@ -17,7 +17,7 @@ spec:
       containers:
       - name: network-store-server
         image: docker.io/powsybl/network-store-server:latest
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 80
         volumeMounts:

--- a/k8s/base/notification-server-deployment.yaml
+++ b/k8s/base/notification-server-deployment.yaml
@@ -17,7 +17,7 @@ spec:
       containers:
       - name: notification-server
         image: docker.io/gridsuite/notification-server:latest
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 80
         volumeMounts:

--- a/k8s/base/odre-server-deployment.yaml
+++ b/k8s/base/odre-server-deployment.yaml
@@ -17,7 +17,7 @@ spec:
       containers:
       - name: odre
         image: docker.io/gridsuite/odre-server:latest
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 80
         volumeMounts:

--- a/k8s/base/single-line-diagram-server-deployment.yaml
+++ b/k8s/base/single-line-diagram-server-deployment.yaml
@@ -17,7 +17,7 @@ spec:
       containers:
       - name: single-line-diagram-server
         image: docker.io/powsybl/single-line-diagram-server:latest
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 80
         volumeMounts:

--- a/k8s/base/study-app-deployment.yaml
+++ b/k8s/base/study-app-deployment.yaml
@@ -17,7 +17,7 @@ spec:
       containers:
       - name: study-app
         image: docker.io/powsybl/study-app:latest
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 80
         volumeMounts:

--- a/k8s/base/study-server-deployment.yaml
+++ b/k8s/base/study-server-deployment.yaml
@@ -17,7 +17,7 @@ spec:
       containers:
         - name: study
           image: docker.io/powsybl/study-server:latest
-          imagePullPolicy: Always
+          imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 80
           volumeMounts:

--- a/k8s/overlays/local/oidc-mock-server-deployment.yaml
+++ b/k8s/overlays/local/oidc-mock-server-deployment.yaml
@@ -17,7 +17,7 @@ spec:
       containers:
       - name: oidc-mock-server
         image: docker.io/gridsuite/oidc-mock-server:latest
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 3000
         env:


### PR DESCRIPTION
The options are (https://kubernetes.io/docs/concepts/configuration/overview/#container-images)
> The imagePullPolicy and the tag of the image affect when the kubelet attempts to pull the specified image.
> * imagePullPolicy: IfNotPresent: the image is pulled only if it is not already present locally.
> * imagePullPolicy: Always: every time the kubelet launches a container, the kubelet queries the container image registry to resolve the name to an image digest. If the kubelet has a container image with that exact digest cached locally, the kubelet uses its cached image; otherwise, the kubelet downloads (pulls) the image with the resolved digest, and uses that image to launch the container.
> * imagePullPolicy is omitted and either the image tag is :latest or it is omitted: Always is applied.
> * imagePullPolicy is omitted and the image tag is present but not :latest: IfNotPresent is applied.
> * imagePullPolicy: Never: the image is assumed to exist locally. No attempt is made to pull the image.

So  ```imagePullPolicy: IfNotPresent``` seems like the best choice: for CI we use a script to replace the tag with it's sha before calling kubectly apply so it will update; for local dev on minikube people can do ```eval $(minikube docker-env)``` to upload new images which will be used when the pod is recreated.

Signed-off-by: Jon Harper <jon.harper87@gmail.com>