### PR TITLE
Case import job can now work within docker-compose

### DIFF
--- a/docker-compose/case-import-job/Dockerfile
+++ b/docker-compose/case-import-job/Dockerfile
@@ -1,0 +1,5 @@
+FROM gridsuite/case-import-job:latest
+ENTRYPOINT []
+RUN apt-get update && apt-get -y install cron
+COPY init-job-container.sh /root
+CMD /root/init-job-container.sh

--- a/docker-compose/case-import-job/case-import-job-config.yml
+++ b/docker-compose/case-import-job/case-import-job-config.yml
@@ -1,0 +1,13 @@
+sftp-server:
+  hostname: <TO_COMPLETE>
+  username: <TO_COMPLETE>
+  password: <TO_COMPLETE>
+  cases-directory: ./opde
+  label: opde
+
+cassandra:
+  contact-points: <TO_COMPLETE>
+  port: 9042
+
+case-server:
+  url: http://case-server/

--- a/docker-compose/case-import-job/init-job-container.sh
+++ b/docker-compose/case-import-job/init-job-container.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# Create log file for job execution
+touch /root/job-execution.log
+# Create env vars to access from crontab
+printenv | sed 's/^\(.*\)$/export \1/g' > /root/project_env.sh
+# Setup crontab from cron file
+crontab /root/job-crontab
+# Start cron daemon
+service cron start
+# Display job execution log file content
+tail -f /root/job-execution.log

--- a/docker-compose/case-import-job/job-crontab
+++ b/docker-compose/case-import-job/job-crontab
@@ -1,0 +1,1 @@
+*/5 * * * * . /root/project_env.sh; java -cp /app/resources:/app/classes:/app/libs/* org.gridsuite.cases.importer.job.SftpCaseAcquisitionJob >> /root/job-execution.log 2>&1

--- a/docker-compose/merging/docker-compose.override.yml
+++ b/docker-compose/merging/docker-compose.override.yml
@@ -39,3 +39,8 @@ services:
       - $PWD/../../k8s/base/config/cgmes-boundary-server-application.yml:/config/application.yml:Z
       - $PWD/../cassandra.properties:/config/cassandra.properties:Z
 
+  case-import-job:
+    build: case-import-job
+    volumes:
+      - $PWD/../case-import-job/job-crontab:/root/job-crontab:Z
+      - $PWD/../case-import-job/case-import-job-config.yml:/root/.itools/config.yml:Z


### PR DESCRIPTION
Case import job is now run with docker-compose in a specific container (with a crontab).

Signed-off-by: NOIR Nicolas ext <nicolas.noir@rte-france.com>