### PR TITLE
Addition of network-conversion-server in merging profile

### DIFF
--- a/docker-compose/docker-compose.base.yml
+++ b/docker-compose/docker-compose.base.yml
@@ -37,6 +37,13 @@ services:
       - $PWD/../../k8s/base/config/network-store-server-application.yml:/config/application.yml:Z
       - $PWD/../cassandra.properties:/config/cassandra.properties:Z
 
+  network-conversion-server:
+    image: powsybl/network-conversion-server:latest
+    ports:
+      - 5003:80
+    volumes:
+      - $PWD/../../k8s/base/config/network-conversion-server-application.yml:/config/application.yml:Z
+
   loadflow-server:
     image: gridsuite/loadflow-server:latest
     ports:

--- a/docker-compose/study/docker-compose.override.yml
+++ b/docker-compose/study/docker-compose.override.yml
@@ -39,13 +39,6 @@ services:
     volumes:
       - $PWD/../../k8s/base/config/notification-server-application.yml:/config/application.yml:Z
 
-  network-conversion-server:
-    image: powsybl/network-conversion-server:latest
-    ports:
-      - 5003:80
-    volumes:
-      - $PWD/../../k8s/base/config/network-conversion-server-application.yml:/config/application.yml:Z
-
   network-map-server:
     image: gridsuite/network-map-server:latest
     ports:

--- a/k8s/base/config/merge-orchestrator-server-application.yml
+++ b/k8s/base/config/merge-orchestrator-server-application.yml
@@ -14,6 +14,8 @@ backing-services:
     base-uri: http://loadflow-server/
   case-validation-server:
     base-uri: http://case-validation-server/
+  network-conversion:
+    base-uri: http://network-conversion-server/
 
 parameters:
   tsos: BE,NL


### PR DESCRIPTION
In order for the new merge export functionnality to work, network-conversion-server has to be deployed when using docker-compose merging profile.

Signed-off-by: NOIR Nicolas ext <nicolas.noir@rte-france.com>