### PR TITLE
Fix case-server pod upgrading

### DIFF
--- a/k8s/base/case-server-deployment.yaml
+++ b/k8s/base/case-server-deployment.yaml
@@ -9,6 +9,8 @@ spec:
   selector:
     matchLabels:
       name: case-server
+  strategy:
+    type: Recreate
   template:
     metadata:
       labels:


### PR DESCRIPTION
In our azure deployment, when we modify the case-server, the new pod is stuck in ContainerCreating:

case-server-594f9d8b99-kbs52                   1/1     Running             0          13d
case-server-d66b95bb5-hhppn                    0/1     ContainerCreating   0          18m

default     19m         Normal    SuccessfulCreate     replicaset/case-server-d66b95bb5                     Created pod: case-server-d66b95bb5-hhppn
default     19m         Normal    ScalingReplicaSet    deployment/case-server                               Scaled up replica set case-server-d66b95bb5 to 1
default     19m         Warning   FailedAttachVolume   pod/case-server-d66b95bb5-hhppn                      Multi-Attach error for volume "pvc-4cfd6be3-e4cd-4b85-b19f-267b10c7d274" Volume is already used by pod(s) case-server-594f9d8b99-kbs52
default     19m         Normal    Scheduled            pod/case-server-d66b95bb5-hhppn                      Successfully assigned default/case-server-d66b95bb5-hhppn to aks-nodepool1-75302467-vmss000005
default     8m28s       Warning   FailedMount          pod/case-server-d66b95bb5-hhppn                      Unable to attach or mount volumes: unmounted volumes=[case-server-storage], unattached volumes=[default-token-56hgl case-server-configmap-volume case-server-storage]: timed out waiting for the condition
default     103s        Warning   FailedMount          pod/case-server-d66b95bb5-hhppn                      Unable to attach or mount volumes: unmounted volumes=[case-server-storage], unattached volumes=[case-server-configmap-volume case-server-storage default-token-56hgl]: timed out waiting for the condition

Signed-off-by: Jon Harper <jon.harper87@gmail.com>