### PR TITLE
Ingresses: use service instead of pods to try and avoid prod problem

### DIFF
--- a/k8s/base/apps-metadata-server-ingress.yaml
+++ b/k8s/base/apps-metadata-server-ingress.yaml
@@ -3,6 +3,7 @@ kind: Ingress
 metadata:
   name: apps-metadata-server-ingress
   annotations:
+    nginx.ingress.kubernetes.io/service-upstream: "true"
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
     nginx.ingress.kubernetes.io/rewrite-target: /$2
     # springfox swagger-ui uses X-Forwarded-Prefix to find the

--- a/k8s/base/gridactions-app-ingress.yaml
+++ b/k8s/base/gridactions-app-ingress.yaml
@@ -3,6 +3,7 @@ kind: Ingress
 metadata:
   name: gridactions-app-ingress
   annotations:
+    nginx.ingress.kubernetes.io/service-upstream: "true"
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
     nginx.ingress.kubernetes.io/rewrite-target: /$2
     # springfox swagger-ui uses X-Forwarded-Prefix to find the

--- a/k8s/base/gridmerge-app-ingress.yaml
+++ b/k8s/base/gridmerge-app-ingress.yaml
@@ -3,6 +3,7 @@ kind: Ingress
 metadata:
   name: gridmerge-app-ingress
   annotations:
+    nginx.ingress.kubernetes.io/service-upstream: "true"
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
     nginx.ingress.kubernetes.io/rewrite-target: /$2
     # springfox swagger-ui uses X-Forwarded-Prefix to find the

--- a/k8s/base/gridstudy-app-ingress.yaml
+++ b/k8s/base/gridstudy-app-ingress.yaml
@@ -3,6 +3,7 @@ kind: Ingress
 metadata:
   name: gridstudy-app-ingress
   annotations:
+    nginx.ingress.kubernetes.io/service-upstream: "true"
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
     nginx.ingress.kubernetes.io/rewrite-target: /$2
     # springfox swagger-ui uses X-Forwarded-Prefix to find the


### PR DESCRIPTION
In production, we see the nginx-ingress-controller performing a request on
the podIP, but the request is actually received and handled by another pod.
We don't understand what's happening.

Signed-off-by: Jon Harper <jon.harper87@gmail.com>