### PR TITLE
GridExplore as GridSuite main entry point

### DIFF
--- a/docker-compose/apps-metadata.json
+++ b/docker-compose/apps-metadata.json
@@ -1,13 +1,18 @@
-[{
-  "name" : "Merge",
-  "url"  : "http://localhost:81",
-  "appColor" : "#2D9BF0"
+[
+{
+  "name" : "Explore",
+  "url"  : "http://localhost:80",
+  "appColor" : "#33AFED"
 },
 {
   "name" : "Study",
-  "url"  : "http://localhost:80",
+  "url"  : "http://localhost:84",
   "appColor" : "#0CA789"
-
+},
+{
+  "name" : "Merge",
+  "url"  : "http://localhost:81",
+  "appColor" : "#2D9BF0"
 },
 {
   "name" : "Actions",
@@ -18,9 +23,5 @@
   "name" : "Dynamic Mapping",
   "url"  : "http://localhost:83",
   "appColor" : "#FFC11B"
-},
-{
-  "name" : "Explore",
-  "url"  : "http://localhost:84",
-  "appColor" : "#33AFED"
-}]
+}
+]

--- a/docker-compose/docker-compose.base.yml
+++ b/docker-compose/docker-compose.base.yml
@@ -203,7 +203,7 @@ services:
     environment:
       - PORT=9090
       - CLIENT_COUNT=6
-      - CLIENT_ID=gridstudy-client
+      - CLIENT_ID=gridexplore-client
       - CLIENT_REDIRECT_URI=http://localhost:80/sign-in-callback
       - CLIENT_LOGOUT_REDIRECT_URI=http://localhost:80/logout-callback
       - CLIENT_SILENT_REDIRECT_URI=http://localhost:80/silent-renew-callback
@@ -223,7 +223,7 @@ services:
       - CLIENT_REDIRECT_URI_5=http://localhost:83/sign-in-callback
       - CLIENT_LOGOUT_REDIRECT_URI_5=http://localhost:83/logout-callback
       - CLIENT_SILENT_REDIRECT_URI_5=http://localhost:83/silent-renew-callback
-      - CLIENT_ID_6=gridexplore-client
+      - CLIENT_ID_6=gridstudy-client
       - CLIENT_REDIRECT_URI_6=http://localhost:84/sign-in-callback
       - CLIENT_LOGOUT_REDIRECT_URI_6=http://localhost:84/logout-callback
       - CLIENT_SILENT_REDIRECT_URI_6=http://localhost:84/silent-renew-callback

--- a/docker-compose/gridexplore-app-idpSettings.json
+++ b/docker-compose/gridexplore-app-idpSettings.json
@@ -1,8 +1,8 @@
 {
     "authority" : "http://172.17.0.1:9090/",
     "client_id" : "gridexplore-client",
-    "redirect_uri": "http://localhost:84/sign-in-callback",
-    "post_logout_redirect_uri" : "http://localhost:84/logout-callback",
-    "silent_redirect_uri" : "http://localhost:84/silent-renew-callback",
+    "redirect_uri": "http://localhost:80/sign-in-callback",
+    "post_logout_redirect_uri" : "http://localhost:80/logout-callback",
+    "silent_redirect_uri" : "http://localhost:80/silent-renew-callback",
     "scope" : "openid"
 }

--- a/docker-compose/gridstudy-app-idpSettings.json
+++ b/docker-compose/gridstudy-app-idpSettings.json
@@ -1,8 +1,8 @@
 {
     "authority" : "http://172.17.0.1:9090/",
     "client_id" : "gridstudy-client",
-    "redirect_uri": "http://localhost:80/sign-in-callback",
-    "post_logout_redirect_uri" : "http://localhost:80/logout-callback",
-    "silent_redirect_uri" : "http://localhost:80/silent-renew-callback",
+    "redirect_uri": "http://localhost:84/sign-in-callback",
+    "post_logout_redirect_uri" : "http://localhost:84/logout-callback",
+    "silent_redirect_uri" : "http://localhost:84/silent-renew-callback",
     "scope" : "openid"
 }

--- a/docker-compose/study/docker-compose.override.yml
+++ b/docker-compose/study/docker-compose.override.yml
@@ -134,7 +134,7 @@ services:
   gridstudy-app:
     image: gridsuite/gridstudy-app:latest
     ports:
-      - 80:8080
+      - 84:8080
     volumes:
       - $PWD/../gridstudy-app-idpSettings.json:/opt/bitnami/apache/htdocs/gridstudy/idpSettings.json:Z
       - $PWD/../env.json:/opt/bitnami/apache/htdocs/gridstudy/env.json:Z
@@ -190,7 +190,7 @@ services:
   gridexplore-app:
     image: gridsuite/gridexplore-app:latest
     ports:
-      - 84:8080
+      - 80:8080
     volumes:
       - $PWD/../gridexplore-app-idpSettings.json:/opt/bitnami/apache/htdocs/gridexplore/idpSettings.json:Z
       - $PWD/../env.json:/opt/bitnami/apache/htdocs/gridexplore/env.json:Z


### PR DESCRIPTION
For docker-compose environment.
For Azure the redirection of "/" on "/gridexplore" does the job
Will need another PR to correct the 
`href = appsAndUrls[1].url + '/studies/' + elementUuid;`
in directory-content.js getLink