### PR TITLE
fix(gridexplore-idpSettings): 

### DIFF
--- a/k8s/overlays/local/gridexplore-app-idpSettings.json
+++ b/k8s/overlays/local/gridexplore-app-idpSettings.json
@@ -1,8 +1,8 @@
 {
-    "authority" : "http://<TO COMPLETE>/oidc-mock-server/",
+    "authority" : "http://<INGRESS_HOST>/oidc-mock-server/",
     "client_id" : "gridexplore-client",
-    "redirect_uri": "http://<TO COMPLETE>/gridexplore/sign-in-callback",
-    "post_logout_redirect_uri" : "http://<TO COMPLETE>/gridexplore/logout-callback",
-    "silent_redirect_uri" : "http://<TO COMPLETE>/gridexplore/silent-renew-callback",
+    "redirect_uri": "http://<INGRESS_HOST>/gridexplore/sign-in-callback",
+    "post_logout_redirect_uri" : "http://<INGRESS_HOST>/gridexplore/logout-callback",
+    "silent_redirect_uri" : "http://<INGRESS_HOST>/gridexplore/silent-renew-callback",
     "scope" : "openid"
 }


### PR DESCRIPTION
replace <TO_COMPLETE> to <INGRESS_HOST> to allow setting by sed command like other client services (see gridstudy-app-idpSettings.json and others if needed)