### PR TITLE
fix loadflow on merging view

### DIFF
--- a/docker-compose/merging/docker-compose.override.yml
+++ b/docker-compose/merging/docker-compose.override.yml
@@ -42,6 +42,7 @@ services:
     volumes:
       - $PWD/../../k8s/base/config/balances-adjustment-server-application.yml:/config/specific/application.yml:Z
       - $PWD/../../k8s/base/config/common-application.yml:/config/common/application.yml:Z
+      - $PWD/../../k8s/base/config/balances-adjustment-server-config.yml:/home/powsybl/.itools/config.yml:Z
     depends_on:
       - logspout
     environment:

--- a/k8s/base/config/balances-adjustment-server-config.yml
+++ b/k8s/base/config/balances-adjustment-server-config.yml
@@ -1,7 +1,3 @@
-hades2:
-  homeDir: /hades2
-  debug: false
-
 #Workaround iidm in-memory impl present on classpath (needed by cvg-extension)
 network:
-  default-impl-name: NetworkStore
+  default-impl-name: Default

--- a/k8s/base/config/security-analysis-server-config.yml
+++ b/k8s/base/config/security-analysis-server-config.yml
@@ -1,3 +1,7 @@
 hades2:
   homeDir: /hades2
   debug: false
+
+#Workaround iidm in-memory impl present on classpath (needed by cvg-extension)
+network:
+  default-impl-name: NetworkStore

--- a/k8s/base/kustomization.yaml
+++ b/k8s/base/kustomization.yaml
@@ -181,6 +181,9 @@ configMapGenerator:
   - name: balances-adjustment-server-configmap-specific
     files:
       - application.yml=config/balances-adjustment-server-application.yml
+  - name: balances-adjustment-server-itools-configmap
+    files:
+      - config.yml=config/balances-adjustment-server-config.yml
   - name: notification-server-configmap-common
     files:
       - application.yml=config/common-application.yml


### PR DESCRIPTION
com.powsybl.commons.PowsyblException: Several NetworkFactoryService implementations found ([Default, NetworkStore]), you must add configuration in PlatformConfig's module "network" to select the implementation
	at com.powsybl.commons.config.PlatformConfigNamedProvider$Finder.find(PlatformConfigNamedProvider.java:186) ~[powsybl-commons-4.7.0.jar:na]
	at com.powsybl.commons.config.PlatformConfigNamedProvider$Finder.find(PlatformConfigNamedProvider.java:150) ~[powsybl-commons-4.7.0.jar:na]
	at com.powsybl.commons.config.PlatformConfigNamedProvider$Finder.find(PlatformConfigNamedProvider.java:89) ~[powsybl-commons-4.7.0.jar:na]
	at com.powsybl.iidm.network.NetworkFactory.find(NetworkFactory.java:34) ~[powsybl-iidm-api-4.7.0.jar:na]
	at com.powsybl.iidm.network.NetworkFactory.findDefault(NetworkFactory.java:46) ~[powsybl-iidm-api-4.7.0.jar:na]
	at com.powsybl.iidm.mergingview.MergingView.create(MergingView.java:171) ~[powsybl-iidm-mergingview-4.7.0.jar:na]
	at org.gridsuite.loadflow.server.LoadFlowService.loadFlow(LoadFlowService.java:107) ~[classes/:na]
	at org.gridsuite.loadflow.server.LoadFlowController.loadFlow(LoadFlowController.java:61) ~[classes/:na]

Signed-off-by: HARPER Jon <jon.harper87@gmail.com>