### PR TITLE
Oops: powsybl can't have empty config files

### DIFF
--- a/docker-compose/docker-compose.base.yml
+++ b/docker-compose/docker-compose.base.yml
@@ -95,7 +95,6 @@ services:
     volumes:
       - $PWD/../../k8s/base/config/network-conversion-server-application.yml:/config/specific/application.yml:Z
       - $PWD/../../k8s/base/config/common-application.yml:/config/common/application.yml:Z
-      - $PWD/../../k8s/base/config/network-conversion-server-config.yml:/home/powsybl/.itools/config.yml:Z
     restart:
       unless-stopped
     depends_on:

--- a/k8s/base/kustomization.yaml
+++ b/k8s/base/kustomization.yaml
@@ -113,9 +113,6 @@ configMapGenerator:
   - name: network-conversion-server-configmap-specific
     files:
       - application.yml=config/network-conversion-server-application.yml
-  - name: network-conversion-server-itools-configmap
-    files:
-      - config.yml=config/network-conversion-server-config.yml
   - name: network-map-server-configmap-common
     files:
       - application.yml=config/common-application.yml

--- a/k8s/base/network-conversion-server-deployment.yaml
+++ b/k8s/base/network-conversion-server-deployment.yaml
@@ -28,8 +28,6 @@ spec:
           name: network-conversion-server-configmap-common-volume
         - mountPath: /config/specific
           name: network-conversion-server-configmap-specific-volume
-        - mountPath: /home/powsybl/.itools
-          name: network-conversion-server-itools-configmap-volume
         - mountPath: /tmp
           name: tmp-emptydir
         securityContext:
@@ -69,8 +67,5 @@ spec:
         - name: network-conversion-server-configmap-specific-volume
           configMap:
             name: network-conversion-server-configmap-specific
-        - name: network-conversion-server-itools-configmap-volume
-          configMap:
-            name: network-conversion-server-itools-configmap
         - name: tmp-emptydir
           emptyDir: {}


### PR DESCRIPTION
Caused by: com.powsybl.commons.PowsyblException: Named modules are expected at the first level of the YAML
	at com.powsybl.commons.config.YamlModuleConfigRepository.<init>(YamlModuleConfigRepository.java:34) ~[powsybl-commons-4.8.0.jar:na]