### PR TITLE
fix: add missing MaxRamPercentage to odre-server

### DIFF
--- a/k8s/base/odre-server-deployment.yaml
+++ b/k8s/base/odre-server-deployment.yaml
@@ -18,6 +18,9 @@ spec:
       - name: odre
         image: docker.io/gridsuite/odre-server:latest
         imagePullPolicy: IfNotPresent
+        env:
+        - name: JAVA_TOOL_OPTIONS
+          value: "-XX:MaxRAMPercentage=75"
         ports:
         - containerPort: 8080
         volumeMounts:


### PR DESCRIPTION
This means the xmx was only 256Mi.. reset it to 768 but do we need it ? compare with all others, for example network-map-server-deployment.yaml

Signed-off-by: HARPER Jon <jon.harper87@gmail.com>