### PR TITLE
Fix azure deployment, regression from 4ec9c88ad96ee4f

### DIFF
--- a/k8s/overlays/azure-dev/kustomization.yaml
+++ b/k8s/overlays/azure-dev/kustomization.yaml
@@ -42,6 +42,7 @@ configMapGenerator:
     files:
       - allowed-issuers.yml
   - name: common-application-configmap
+    behavior: merge
     files:
       - application.yml=common-application.yml
 

--- a/k8s/overlays/azure-integ/kustomization.yaml
+++ b/k8s/overlays/azure-integ/kustomization.yaml
@@ -30,6 +30,7 @@ configMapGenerator:
     files:
       - env.json=env.json
   - name: common-application-configmap
+    behavior: merge
     files:
       - application.yml=common-application.yml
 


### PR DESCRIPTION
error: merging from generator &{0xc001e17650 {  map[] map[]} {{ common-application-configmap  {[] [application.yml=common-application.yml] [] } <nil>}}}: id resid.ResId{Gvk:resid.Gvk{Group:"", Version:"v1", Kind:"ConfigMap", isClusterScoped:false}, Name:"common-application-configmap", Namespace:""} exists; behavior must be merge or replace