### PR TITLE
Sizetweaks

### DIFF
--- a/docker-compose/docker-compose.base.yml
+++ b/docker-compose/docker-compose.base.yml
@@ -13,7 +13,7 @@ services:
     depends_on:
       - logspout
     environment:
-      - JAVA_TOOL_OPTIONS=-Xmx768m
+      - JAVA_TOOL_OPTIONS=-Xmx512m
     command: --server.port=80 --spring.config.additional-location=/config/
     sysctls:
         - net.ipv4.ip_unprivileged_port_start=0 # for docker < 20.03.0
@@ -70,7 +70,7 @@ services:
     sysctls:
       - net.ipv4.ip_unprivileged_port_start=0 # for docker < 20.03.0
     environment:
-      - JAVA_TOOL_OPTIONS=-Xmx768m
+      - JAVA_TOOL_OPTIONS=-Xmx512m
 
   network-store-server:
     image: powsybl/network-store-server:latest
@@ -85,7 +85,7 @@ services:
     depends_on:
       - logspout
     environment:
-      - JAVA_TOOL_OPTIONS=-Xmx768m
+      - JAVA_TOOL_OPTIONS=-Xmx1792m
     command: --server.port=80 --spring.config.additional-location=/config/
     sysctls:
         - net.ipv4.ip_unprivileged_port_start=0 # for docker < 20.03.0
@@ -102,7 +102,7 @@ services:
     depends_on:
       - logspout
     environment:
-      - JAVA_TOOL_OPTIONS=-Xmx768m
+      - JAVA_TOOL_OPTIONS=-Xmx1792m
     command: --server.port=80 --spring.config.additional-location=/config/
     sysctls:
         - net.ipv4.ip_unprivileged_port_start=0 # for docker < 20.03.0

--- a/docker-compose/study/docker-compose.override.yml
+++ b/docker-compose/study/docker-compose.override.yml
@@ -48,7 +48,7 @@ services:
     depends_on:
       - logspout
     environment:
-      - JAVA_TOOL_OPTIONS=-Xmx768m
+      - JAVA_TOOL_OPTIONS=-Xmx1792m
     command: --server.port=80 --spring.config.additional-location=/config/
     sysctls:
         - net.ipv4.ip_unprivileged_port_start=0 # for docker < 20.03.0
@@ -170,7 +170,7 @@ services:
     depends_on:
       - logspout
     environment:
-      - JAVA_TOOL_OPTIONS=-Xmx1024m
+      - JAVA_TOOL_OPTIONS=-Xmx768m
     command: --server.port=80 --spring.config.additional-location=/config/
     sysctls:
         - net.ipv4.ip_unprivileged_port_start=0 # for docker < 20.03.0
@@ -206,7 +206,7 @@ services:
     depends_on:
       - logspout
     environment:
-      - JAVA_TOOL_OPTIONS=-Xmx128m
+      - JAVA_TOOL_OPTIONS=-Xmx256m
     command: --server.port=80 --spring.config.additional-location=/config/
     sysctls:
       - net.ipv4.ip_unprivileged_port_start=0 # for docker < 20.03.0
@@ -231,7 +231,7 @@ services:
     depends_on:
       - logspout
     environment:
-      - JAVA_TOOL_OPTIONS=-Xmx128m
+      - JAVA_TOOL_OPTIONS=-Xmx768m
     command: --server.port=80 --spring.config.additional-location=/config/
     sysctls:
       - net.ipv4.ip_unprivileged_port_start=0 # for docker < 20.03.0

--- a/k8s/components/gridsuite/patches/deployments-springboot-size-l-forking.yaml
+++ b/k8s/components/gridsuite/patches/deployments-springboot-size-l-forking.yaml
@@ -9,7 +9,7 @@ spec:
         - name: main
           env:
           - name: JAVA_TOOL_OPTIONS
-            value: "-Xmx1024m"
+            value: "-Xmx768m"
           resources:
             requests:
               memory: "1.5Gi"

--- a/k8s/resources/common/case-server-deployment.yaml
+++ b/k8s/resources/common/case-server-deployment.yaml
@@ -7,7 +7,7 @@ metadata:
     version: "1"
     app.kubernetes.io/component: gridsuite-springboot
   annotations:
-    gridsuite.org/size: springboot-l
+    gridsuite.org/size: springboot-m
 spec:
   selector:
     matchLabels:

--- a/k8s/resources/common/loadflow-server-deployment.yaml
+++ b/k8s/resources/common/loadflow-server-deployment.yaml
@@ -7,7 +7,7 @@ metadata:
     version: "1"
     app.kubernetes.io/component: gridsuite-springboot
   annotations:
-    gridsuite.org/size: springboot-l
+    gridsuite.org/size: springboot-l-forking
 spec:
   selector:
     matchLabels:

--- a/k8s/resources/common/network-conversion-server-deployment.yaml
+++ b/k8s/resources/common/network-conversion-server-deployment.yaml
@@ -7,7 +7,7 @@ metadata:
     version: "1"
     app.kubernetes.io/component: gridsuite-springboot
   annotations:
-    gridsuite.org/size: springboot-l
+    gridsuite.org/size: springboot-xl
 spec:
   selector:
     matchLabels:

--- a/k8s/resources/common/network-store-server-deployment.yaml
+++ b/k8s/resources/common/network-store-server-deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/component: gridsuite-springboot
     gridsuite.org/springboot-with-database: "true"
   annotations:
-    gridsuite.org/size: springboot-l
+    gridsuite.org/size: springboot-xl
 spec:
   selector:
     matchLabels:

--- a/k8s/resources/common/report-server-deployment.yaml
+++ b/k8s/resources/common/report-server-deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/component: gridsuite-springboot
     gridsuite.org/springboot-with-database: "true"
   annotations:
-    gridsuite.org/size: springboot-l
+    gridsuite.org/size: springboot-m
 spec:
   selector:
     matchLabels:

--- a/k8s/resources/dynamic-mapping/dynamic-mapping-server-deployment.yaml
+++ b/k8s/resources/dynamic-mapping/dynamic-mapping-server-deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/component: gridsuite-springboot
     gridsuite.org/springboot-with-database: "true"
   annotations:
-    gridsuite.org/size: springboot-l
+    gridsuite.org/size: springboot-l # should be m or s ?
 spec:
   selector:
     matchLabels:

--- a/k8s/resources/merging/merge-orchestrator-server-deployment.yaml
+++ b/k8s/resources/merging/merge-orchestrator-server-deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/component: gridsuite-springboot
     gridsuite.org/springboot-with-database: "true"
   annotations:
-    gridsuite.org/size: springboot-l
+    gridsuite.org/size: springboot-l # should be xs ?
 spec:
   selector:
     matchLabels:

--- a/k8s/resources/study/directory-server-deployment.yaml
+++ b/k8s/resources/study/directory-server-deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/component: gridsuite-springboot
     gridsuite.org/springboot-with-database: "true"
   annotations:
-    gridsuite.org/size: springboot-xs
+    gridsuite.org/size: springboot-s
 spec:
   selector:
     matchLabels:

--- a/k8s/resources/study/dynamic-simulation-server-deployment.yaml
+++ b/k8s/resources/study/dynamic-simulation-server-deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/component: gridsuite-springboot
     gridsuite.org/springboot-with-database: "true"
   annotations:
-    gridsuite.org/size: springboot-l
+    gridsuite.org/size: springboot-l-forking
 spec:
   selector:
     matchLabels:

--- a/k8s/resources/study/explore-server-deployment.yaml
+++ b/k8s/resources/study/explore-server-deployment.yaml
@@ -7,7 +7,7 @@ metadata:
     version: "1"
     app.kubernetes.io/component: gridsuite-springboot
   annotations:
-    gridsuite.org/size: springboot-xs
+    gridsuite.org/size: springboot-m
 spec:
   selector:
     matchLabels:

--- a/k8s/resources/study/single-line-diagram-server-deployment.yaml
+++ b/k8s/resources/study/single-line-diagram-server-deployment.yaml
@@ -7,7 +7,7 @@ metadata:
     version: "1"
     app.kubernetes.io/component: gridsuite-springboot
   annotations:
-    gridsuite.org/size: springboot-l
+    gridsuite.org/size: springboot-xl
 spec:
   selector:
     matchLabels:


### PR DESCRIPTION

Summary:
```
xs        :384m = jvm(256m) + Xmx128m
s         :512m = jvm(256m) + Xmx256m
m         :768m = jvm(256m) + Xmx512m
l         :1g   = jvm(256m) + Xmx768m
l-forking :1.5g = jvm(256m) + Xmx768m + fork 512m
xl        :2g   = jvm(256m) + Xmx1792m

common : ~ 10g
study  : ~ 12g
merging: ~ 3g
dynamic: ~ 1g

total: ~26g
```

xs:
- case-validation-server
- cgmes-boundary-server
- cgmes-gl-server
- config-notification-server
- config-server
- directory-notification-server
- gateway
- merge-notification-server
- notification-server

s
- directory-server
- explore-server

m
- case-server
- report-server

l
- actions-server
- balances-adjustment-server
- dynamic-mapping-server
- filter-server
- geo-data-server
- merge-orchestrator-server
- network-map-server
- network-modification-server
- odre-server
- study-server

l-forking
- dynamic-simulation-server
- loadflow-server
- security-analysis-server

xl
- network-conversion-server
- network-store-server
- single-line-diagram-server
