### PR TITLE
Revert "default backend is a global ingress controller setting, use prefix match instead"

### DIFF
--- a/k8s/resources/common/root-ingress.yaml
+++ b/k8s/resources/common/root-ingress.yaml
@@ -9,11 +9,16 @@ metadata:
       client_header_buffer_size 64k;
       large_client_header_buffers 4 64k;
 spec:
+  defaultBackend:
+    service:
+      name: default-backend
+      port:
+        number: 80
   rules:
   - http:
       paths:
       - path: /
-        pathType: Prefix
+        pathType: Exact
         backend:
           service:
             name: default-backend


### PR DESCRIPTION
Reverts gridsuite/deployment#287