### PR TITLE
Mount empty dir for tmp dir of dynamic simulation server

### DIFF
--- a/k8s/resources/study/dynamic-simulation-server-deployment.yaml
+++ b/k8s/resources/study/dynamic-simulation-server-deployment.yaml
@@ -28,6 +28,8 @@ spec:
               name: dynawo-config-configmap-volume
             - mountPath: /home/powsybl/.itools
               name: dynawo-itools-configmap-volume
+            - mountPath: /home/powsybl/.itools/tmp
+              name: itoolstmp-emptydir
       volumes:
         - name: dynamic-simulation-server-configmap-specific-volume
           configMap:
@@ -38,3 +40,5 @@ spec:
         - name: dynawo-itools-configmap-volume
           configMap:
             name: dynawo-itools-configmap
+        - name: itoolstmp-emptydir
+          emptyDir: { }


### PR DESCRIPTION
This is a temporary solution in waiting the next version of Dynawaltz which will remove all file-based inputs