### PR TITLE
fix "context not found" with merging jobs

### DIFF
--- a/docker-compose/merging/docker-compose.override.yml
+++ b/docker-compose/merging/docker-compose.override.yml
@@ -105,7 +105,7 @@ services:
       - merging
       - suite
     build:
-      context: merging/case-import-job
+      context: $PWD/../merging/case-import-job
       args:
         - http_proxy=${http_proxy-}
         - https_proxy=${https_proxy-}
@@ -126,7 +126,7 @@ services:
       - merging
       - suite
     build:
-      context: merging/cgmes-assembling-job
+      context: $PWD/../merging/cgmes-assembling-job
       args:
         - http_proxy=${http_proxy-}
         - https_proxy=${https_proxy-}
@@ -161,7 +161,7 @@ services:
       - merging
       - suite
     build:
-      context: merging/cgmes-boundary-import-job
+      context: $PWD/../merging/cgmes-boundary-import-job
       args:
         - http_proxy=${http_proxy-}
         - https_proxy=${https_proxy-}


### PR DESCRIPTION
Fix an error of path resolution with Dockerfiles when in another folder than `merging`
```
~/Dev/GridSuite/deployment/docker-compose/suite$ docker compose up -d
[+] Building 0.0s (0/0)                                                                docker:default
unable to prepare context: path "/home/user/Dev/GridSuite/deployment/docker-compose/suite/merging/cgmes-boundary-import-job" not found
```

Haven't see with #334 that Docker Compose v2 not resolve Dockerfile paths the same way than DCv1.