### PR TITLE
Use Prefix instead of default_backend to implement the catchall 404

### DIFF
--- a/k8s/resources/common/root-ingress.yaml
+++ b/k8s/resources/common/root-ingress.yaml
@@ -9,16 +9,11 @@ metadata:
       client_header_buffer_size 64k;
       large_client_header_buffers 4 64k;
 spec:
-  defaultBackend:
-    service:
-      name: default-backend
-      port:
-        number: 80
   rules:
   - http:
       paths:
       - path: /
-        pathType: Exact
+        pathType: Prefix
         backend:
           service:
             name: default-backend


### PR DESCRIPTION
With ingress nginx the routes are guaranteed to be ordered by length, so '/' so match last
https://kubernetes.github.io/ingress-nginx/user-guide/ingress-path-matching/#path-priority
default backend is a clusterwide setting, we shouldn't use it everywhere
Also in the general ingress docs: https://kubernetes.io/docs/concepts/services-networking/ingress/#multiple-matches
"In some cases, multiple paths within an Ingress will match a request. In those
cases precedence will be given first to the longest matching path. If two paths
are still equally matched, precedence will be given to paths with an exact path
type over prefix path type."

We looked into "nginx.ingress.kubernetes.io/default-backend" which is a namespace-scoped version
of spec.defaultBackend, but it seems only useful to display a custom maintenance page on the real urls of the app
(shown when the service is down because there are no ready pods). To display a custom 404 page on wrong urls,
prefix match '/' is more appropriate.

Note: we already tried this in commit 5286573 but reverted immediately in commit 23bcb5f
because the azure demo deployment broke. This seems to be an issue about the interaction
with our public azure loadbalancer and ingress-nginx, see https://github.com/kubernetes/ingress-nginx/issues/8501#issuecomment-1108428615
Today we added
> service.beta.kubernetes.io/azure-load-balancer-health-probe-request-path: "/healthz"
to our deployed ingress controller on azure and everything works now

