### PR TITLE
Revert "Changing deployment strategy (#296)"

### DIFF
--- a/k8s/components/gridsuite/patches/deployments.yaml
+++ b/k8s/components/gridsuite/patches/deployments.yaml
@@ -3,11 +3,6 @@ kind: Deployment
 metadata:
   name: not-important
 spec:
-  strategy:
-    type: RollingUpdate
-    rollingUpdate:
-      maxSurge: 0
-      maxUnavailable: 1
   template:
     spec:
       containers:

--- a/k8s/resources/common/case-server-deployment.yaml
+++ b/k8s/resources/common/case-server-deployment.yaml
@@ -15,6 +15,8 @@ spec:
   selector:
     matchLabels:
       name: case-server
+  strategy:
+    type: Recreate
   template:
     metadata:
       labels:


### PR DESCRIPTION
This reverts commit ace0a8723fb1ea1106337f02ea96caae47b458ae.

This prevent old pod to be deleted on development environment, use the default "RollingUpdate" strategy.

Case-server need to stay in "Recreate" due to using a ReadWriteOnce pvc