### PR TITLE
Load in-memory metadata file

### DIFF
--- a/docker-compose/gridapps-metadata-httpd.conf
+++ b/docker-compose/gridapps-metadata-httpd.conf
@@ -8,7 +8,10 @@
     Require all granted
   </Directory>
 
+  # Preload in-memory static files often requested
+  LoadModule file_cache_module "modules/mod_file_cache.so"
+  MMapFile /opt/bitnami/apache/htdocs/apps-metadata.json
+
   # Error Documents
   ErrorDocument 503 /503.html
 </VirtualHost>
-

--- a/k8s/live/azure-dev/gridapps-metadata-httpd.conf
+++ b/k8s/live/azure-dev/gridapps-metadata-httpd.conf
@@ -12,6 +12,12 @@
   <FilesMatch "^openid-configuration$">
       ForceType application/json
   </FilesMatch>
+
+  # Preload in-memory static files often requested
+  LoadModule file_cache_module "modules/mod_file_cache.so"
+  MMapFile /opt/bitnami/apache/htdocs/apps-metadata.json
+  MMapFile /opt/bitnami/apache/htdocs/.well-known/openid-configuration
+
   # Error Documents
   ErrorDocument 503 /503.html
 </VirtualHost>

--- a/k8s/resources/common/config/default-backend/httpd.conf
+++ b/k8s/resources/common/config/default-backend/httpd.conf
@@ -7,6 +7,10 @@
     Require all granted
   </Directory>
 
+  # Preload in-memory static files often requested
+  LoadModule file_cache_module "modules/mod_file_cache.so"
+  MMapFile /opt/bitnami/apache/htdocs/apps-metadata.json
+
   # Error Documents
   ErrorDocument 503 /503.html
   ErrorDocument 404 /404.html


### PR DESCRIPTION
While working on [apps-metadata-server caching](https://httpd.apache.org/docs/2.4/fr/caching.html), found [mod_file_cache](https://httpd.apache.org/docs/2.4/fr/mod/mod_file_cache.html) with `MMapFile` to pre-load and keep in-memory the static json file serve to not have an access on disk each time the file is requested, and speed up the response time.

tested under docker compose