### PR TITLE
Add docker compose memory limits

### DIFF
--- a/docker-compose/docker-compose.base.yml
+++ b/docker-compose/docker-compose.base.yml
@@ -21,15 +21,15 @@ services:
       - logspout
     restart: unless-stopped
     environment:
-      - JAVA_TOOL_OPTIONS=-Xmx576m
+      - JAVA_TOOL_OPTIONS=-Xmx576m #deployment: 768m
     command: --server.port=80 --spring.config.additional-location=/config/
     sysctls:
       - net.ipv4.ip_unprivileged_port_start=0 # for docker < 20.03.0
-    memswap_limit: 1g
+    memswap_limit: 1g #deployment: 1280m
     deploy:
       resources:
         limits:
-          memory: 1g
+          memory: 1g #deployment: 1280m
 
   actions-server:
     profiles:
@@ -171,15 +171,15 @@ services:
     depends_on:
       - logspout
     environment:
-      - JAVA_TOOL_OPTIONS=-Xmx1408m
+      - JAVA_TOOL_OPTIONS=-Xmx1086m #deployment: 1408m
     command: --server.port=80 --spring.config.additional-location=/config/
     sysctls:
       - net.ipv4.ip_unprivileged_port_start=0 # for docker < 20.03.0
-    memswap_limit: 2g
+    memswap_limit: 1664m #deployment: 1408m
     deploy:
       resources:
         limits:
-          memory: 2g
+          memory: 1664m #deployment: 1408m
 
   network-conversion-server:
     profiles:
@@ -201,15 +201,15 @@ services:
     depends_on:
       - logspout
     environment:
-      - JAVA_TOOL_OPTIONS=-Xmx1408m
+      - JAVA_TOOL_OPTIONS=-Xmx768m #deployment: 1408m
     command: --server.port=80 --spring.config.additional-location=/config/
     sysctls:
       - net.ipv4.ip_unprivileged_port_start=0 # for docker < 20.03.0
-    memswap_limit: 2g
+    memswap_limit: 1280m  #deployment: 2048m
     deploy:
       resources:
         limits:
-          memory: 2g
+          memory: 1280m  #deployment: 2048m
 
   loadflow-server:
     profiles:
@@ -232,15 +232,15 @@ services:
     depends_on:
       - logspout
     environment:
-      - JAVA_TOOL_OPTIONS=-Xmx1408m
+      - JAVA_TOOL_OPTIONS=-Xmx768m #deployment: 1408m
     command: --server.port=80 --spring.config.additional-location=/config/
     sysctls:
       - net.ipv4.ip_unprivileged_port_start=0 # for docker < 20.03.0
-    memswap_limit: 3g
+    memswap_limit: 1792m #deployment: 3072m
     deploy:
       resources:
         limits:
-          memory: 3g
+          memory: 1792m #deployment: 3072m
 
   config-server:
     profiles:

--- a/docker-compose/docker-compose.base.yml
+++ b/docker-compose/docker-compose.base.yml
@@ -175,11 +175,11 @@ services:
     command: --server.port=80 --spring.config.additional-location=/config/
     sysctls:
       - net.ipv4.ip_unprivileged_port_start=0 # for docker < 20.03.0
-    memswap_limit: 1664m #deployment: 1408m
+    memswap_limit: 1664m #deployment: 2048m
     deploy:
       resources:
         limits:
-          memory: 1664m #deployment: 1408m
+          memory: 1664m #deployment: 2048m
 
   network-conversion-server:
     profiles:

--- a/docker-compose/docker-compose.base.yml
+++ b/docker-compose/docker-compose.base.yml
@@ -21,10 +21,15 @@ services:
       - logspout
     restart: unless-stopped
     environment:
-      - JAVA_TOOL_OPTIONS=-Xmx768m
+      - JAVA_TOOL_OPTIONS=-Xmx576m
     command: --server.port=80 --spring.config.additional-location=/config/
     sysctls:
       - net.ipv4.ip_unprivileged_port_start=0 # for docker < 20.03.0
+    memswap_limit: 1g
+    deploy:
+      resources:
+        limits:
+          memory: 1g
 
   actions-server:
     profiles:
@@ -46,10 +51,15 @@ services:
     depends_on:
       - logspout
     environment:
-      - JAVA_TOOL_OPTIONS=-Xmx768m
+      - JAVA_TOOL_OPTIONS=-Xmx576m
     command: --server.port=80 --spring.config.additional-location=/config/
     sysctls:
       - net.ipv4.ip_unprivileged_port_start=0 # for docker < 20.03.0
+    memswap_limit: 1g
+    deploy:
+      resources:
+        limits:
+          memory: 1g
 
   filter-server:
     profiles:
@@ -74,7 +84,12 @@ services:
     sysctls:
       - net.ipv4.ip_unprivileged_port_start=0 # for docker < 20.03.0
     environment:
-      - JAVA_TOOL_OPTIONS=-Xmx768m
+      - JAVA_TOOL_OPTIONS=-Xmx576m
+    memswap_limit: 1g
+    deploy:
+      resources:
+        limits:
+          memory: 1g
 
   user-admin-server:
     profiles:
@@ -99,7 +114,12 @@ services:
     sysctls:
       - net.ipv4.ip_unprivileged_port_start=0 # for docker < 20.03.0
     environment:
-      - JAVA_TOOL_OPTIONS=-Xmx128m
+      - JAVA_TOOL_OPTIONS=-Xmx96m
+    memswap_limit: 384m
+    deploy:
+      resources:
+        limits:
+          memory: 384m
 
   report-server:
     profiles:
@@ -124,7 +144,12 @@ services:
     sysctls:
       - net.ipv4.ip_unprivileged_port_start=0 # for docker < 20.03.0
     environment:
-      - JAVA_TOOL_OPTIONS=-Xmx512m
+      - JAVA_TOOL_OPTIONS=-Xmx384m
+    memswap_limit: 768m
+    deploy:
+      resources:
+        limits:
+          memory: 768m
 
   network-store-server:
     profiles:
@@ -146,10 +171,15 @@ services:
     depends_on:
       - logspout
     environment:
-      - JAVA_TOOL_OPTIONS=-Xmx1792m
+      - JAVA_TOOL_OPTIONS=-Xmx1408m
     command: --server.port=80 --spring.config.additional-location=/config/
     sysctls:
       - net.ipv4.ip_unprivileged_port_start=0 # for docker < 20.03.0
+    memswap_limit: 2g
+    deploy:
+      resources:
+        limits:
+          memory: 2g
 
   network-conversion-server:
     profiles:
@@ -171,10 +201,15 @@ services:
     depends_on:
       - logspout
     environment:
-      - JAVA_TOOL_OPTIONS=-Xmx1792m
+      - JAVA_TOOL_OPTIONS=-Xmx1408m
     command: --server.port=80 --spring.config.additional-location=/config/
     sysctls:
       - net.ipv4.ip_unprivileged_port_start=0 # for docker < 20.03.0
+    memswap_limit: 2g
+    deploy:
+      resources:
+        limits:
+          memory: 2g
 
   loadflow-server:
     profiles:
@@ -197,10 +232,15 @@ services:
     depends_on:
       - logspout
     environment:
-      - JAVA_TOOL_OPTIONS=-Xmx768m
+      - JAVA_TOOL_OPTIONS=-Xmx1408m
     command: --server.port=80 --spring.config.additional-location=/config/
     sysctls:
       - net.ipv4.ip_unprivileged_port_start=0 # for docker < 20.03.0
+    memswap_limit: 3g
+    deploy:
+      resources:
+        limits:
+          memory: 3g
 
   config-server:
     profiles:
@@ -220,10 +260,15 @@ services:
       - $PWD/../../k8s/resources/common/config/common-application.yml:/config/common/application.yml:Z
     restart: unless-stopped
     environment:
-      - JAVA_TOOL_OPTIONS=-Xmx128m
+      - JAVA_TOOL_OPTIONS=-Xmx96m
     command: --server.port=80 --spring.config.additional-location=/config/
     sysctls:
       - net.ipv4.ip_unprivileged_port_start=0 # for docker < 20.03.0
+    memswap_limit: 384m
+    deploy:
+      resources:
+        limits:
+          memory: 384m
 
   config-notification-server:
     profiles:
@@ -243,10 +288,15 @@ services:
       - $PWD/../../k8s/resources/common/config/common-application.yml:/config/common/application.yml:Z
     restart: unless-stopped
     environment:
-      - JAVA_TOOL_OPTIONS=-Xmx128m
+      - JAVA_TOOL_OPTIONS=-Xmx96m
     command: --server.port=80 --spring.config.additional-location=/config/
     sysctls:
       - net.ipv4.ip_unprivileged_port_start=0 # for docker < 20.03.0
+    memswap_limit: 384m
+    deploy:
+      resources:
+        limits:
+          memory: 384m
 
   gateway:
     profiles:
@@ -269,10 +319,15 @@ services:
     depends_on:
       - logspout
     environment:
-      - JAVA_TOOL_OPTIONS=-Xmx128m
+      - JAVA_TOOL_OPTIONS=-Xmx96m
     command: --server.port=80 --spring.config.additional-location=/config/
     sysctls:
       - net.ipv4.ip_unprivileged_port_start=0 # for docker < 20.03.0
+    memswap_limit: 384m
+    deploy:
+      resources:
+        limits:
+          memory: 384m
 
   mock-user-service:
     profiles:
@@ -332,3 +387,8 @@ services:
       - $PWD/../gridapps-metadata-httpd.conf:/opt/bitnami/apache/conf/bitnami/bitnami.conf:Z
     depends_on:
       - logspout
+    memswap_limit: 128m
+    deploy:
+      resources:
+        limits:
+          memory: 128m

--- a/docker-compose/dynamic-mapping/docker-compose.override.yml
+++ b/docker-compose/dynamic-mapping/docker-compose.override.yml
@@ -15,6 +15,11 @@ services:
       - $PWD/../env.json:/opt/bitnami/apache/htdocs/griddyna/env.json:Z
     depends_on:
       - logspout
+    memswap_limit: 128m
+    deploy:
+      resources:
+        limits:
+          memory: 128m
 
   dynamic-mapping-server:
     profiles:
@@ -32,7 +37,12 @@ services:
     depends_on:
       - logspout
     environment:
-      - JAVA_TOOL_OPTIONS=-Xmx768m
+      - JAVA_TOOL_OPTIONS=-Xmx576m
     command: --server.port=80 --spring.config.additional-location=/config/
     sysctls:
       - net.ipv4.ip_unprivileged_port_start=0 # for docker < 20.03.0
+    memswap_limit: 1g
+    deploy:
+      resources:
+        limits:
+          memory: 1g

--- a/docker-compose/merging/docker-compose.override.yml
+++ b/docker-compose/merging/docker-compose.override.yml
@@ -16,10 +16,15 @@ services:
     depends_on:
       - logspout
     environment:
-      - JAVA_TOOL_OPTIONS=-Xmx768m
+      - JAVA_TOOL_OPTIONS=-Xmx576m
     command: --server.port=80 --spring.config.additional-location=/config/
     sysctls:
       - net.ipv4.ip_unprivileged_port_start=0 # for docker < 20.03.0
+    memswap_limit: 1g
+    deploy:
+      resources:
+        limits:
+          memory: 1g
 
   merge-notification-server:
     profiles:
@@ -35,10 +40,15 @@ services:
     depends_on:
       - logspout
     environment:
-      - JAVA_TOOL_OPTIONS=-Xmx128m
+      - JAVA_TOOL_OPTIONS=-Xmx96m
     command: --server.port=80 --spring.config.additional-location=/config/
     sysctls:
       - net.ipv4.ip_unprivileged_port_start=0 # for docker < 20.03.0
+    memswap_limit: 384m
+    deploy:
+      resources:
+        limits:
+          memory: 384m
 
   balances-adjustment-server:
     profiles:
@@ -55,10 +65,15 @@ services:
     depends_on:
       - logspout
     environment:
-      - JAVA_TOOL_OPTIONS=-Xmx768m
+      - JAVA_TOOL_OPTIONS=-Xmx576m
     command: --server.port=80 --spring.config.additional-location=/config/
     sysctls:
       - net.ipv4.ip_unprivileged_port_start=0 # for docker < 20.03.0
+    memswap_limit: 1g
+    deploy:
+      resources:
+        limits:
+          memory: 1g
 
   case-validation-server:
     profiles:
@@ -74,10 +89,15 @@ services:
     depends_on:
       - logspout
     environment:
-      - JAVA_TOOL_OPTIONS=-Xmx128m
+      - JAVA_TOOL_OPTIONS=-Xmx96m
     command: --server.port=80 --spring.config.additional-location=/config/
     sysctls:
       - net.ipv4.ip_unprivileged_port_start=0 # for docker < 20.03.0
+    memswap_limit: 384m
+    deploy:
+      resources:
+        limits:
+          memory: 384m
 
   cgmes-boundary-server:
     profiles:
@@ -94,10 +114,15 @@ services:
     depends_on:
       - logspout
     environment:
-      - JAVA_TOOL_OPTIONS=-Xmx128m
+      - JAVA_TOOL_OPTIONS=-Xmx96m
     command: --server.port=80 --spring.config.additional-location=/config/
     sysctls:
       - net.ipv4.ip_unprivileged_port_start=0 # for docker < 20.03.0
+    memswap_limit: 384m
+    deploy:
+      resources:
+        limits:
+          memory: 384m
 
   case-import-job:
     profiles:
@@ -154,6 +179,11 @@ services:
       - $PWD/../env.json:/opt/bitnami/apache/htdocs/gridmerge/env.json:Z
     depends_on:
       - logspout
+    memswap_limit: 128m
+    deploy:
+      resources:
+        limits:
+          memory: 128m
 
   cgmes-boundary-import-job:
     profiles:

--- a/docker-compose/study/docker-compose.override.yml
+++ b/docker-compose/study/docker-compose.override.yml
@@ -482,15 +482,15 @@ services:
     depends_on:
       - logspout
     environment:
-      - JAVA_TOOL_OPTIONS=-Xmx768m # deployment: -Xmx1408m
+      - JAVA_TOOL_OPTIONS=-Xmx768m # deployment: -Xmx1086m
     command: --server.port=80 --spring.config.additional-location=/config/
     sysctls:
       - net.ipv4.ip_unprivileged_port_start=0 # for docker < 20.03.0
-    memswap_limit: 1792m # deployment: 3072m
+    memswap_limit: 1792m # deployment: 2432m
     deploy:
       resources:
         limits:
-          memory: 1792m # deployment: 3072m
+          memory: 1792m # deployment: 2432m
 
   #just here for dev purpose, we don't want to start with this profile unless we need to.
   case-import-server:

--- a/docker-compose/study/docker-compose.override.yml
+++ b/docker-compose/study/docker-compose.override.yml
@@ -277,15 +277,15 @@ services:
     depends_on:
       - logspout
     environment:
-      - JAVA_TOOL_OPTIONS=-Xmx1408m
+      - JAVA_TOOL_OPTIONS=-Xmx768m #deployment: 1408m
     command: --server.port=80 --spring.config.additional-location=/config/
     sysctls:
       - net.ipv4.ip_unprivileged_port_start=0 # for docker < 20.03.0
-    memswap_limit: 3g
+    memswap_limit: 1792m #deployment: 3072m
     deploy:
       resources:
         limits:
-          memory: 3g
+          memory: 1792m #deployment: 3072m
 
   dynamic-simulation-server:
     profiles:
@@ -404,15 +404,15 @@ services:
     depends_on:
       - logspout
     environment:
-      - JAVA_TOOL_OPTIONS=-Xmx1408m
+      - JAVA_TOOL_OPTIONS=-Xmx768m
     command: --server.port=80 --spring.config.additional-location=/config/
     sysctls:
       - net.ipv4.ip_unprivileged_port_start=0 # for docker < 20.03.0
-    memswap_limit: 3g
+    memswap_limit: 1792m # deployment: 3072m
     deploy:
       resources:
         limits:
-          memory: 3g
+          memory: 1792m # deployment: 3072m
 
   shortcircuit-server:
     profiles:

--- a/docker-compose/study/docker-compose.override.yml
+++ b/docker-compose/study/docker-compose.override.yml
@@ -506,12 +506,12 @@ services:
     depends_on:
       - logspout
     environment:
-      - JAVA_TOOL_OPTIONS=-Xmx576m # deployment: 768m
+      - JAVA_TOOL_OPTIONS=-Xmx96m
     command: --server.port=80 --spring.config.additional-location=/config/
     sysctls:
       - net.ipv4.ip_unprivileged_port_start=0 # for docker < 20.03.0
-    memswap_limit: 1g # deployment: 1280m
+    memswap_limit: 384m
     deploy:
       resources:
         limits:
-          memory: 1g # deployment: 1280m
+          memory: 384m

--- a/docker-compose/study/docker-compose.override.yml
+++ b/docker-compose/study/docker-compose.override.yml
@@ -404,15 +404,15 @@ services:
     depends_on:
       - logspout
     environment:
-      - JAVA_TOOL_OPTIONS=-Xmx768m
+      - JAVA_TOOL_OPTIONS=-Xmx768m #deployment: 1408m
     command: --server.port=80 --spring.config.additional-location=/config/
     sysctls:
       - net.ipv4.ip_unprivileged_port_start=0 # for docker < 20.03.0
-    memswap_limit: 1792m # deployment: 3072m
+    memswap_limit: 1792m #deployment: 3072m
     deploy:
       resources:
         limits:
-          memory: 1792m # deployment: 3072m
+          memory: 1792m #deployment: 3072m
 
   shortcircuit-server:
     profiles:
@@ -482,15 +482,15 @@ services:
     depends_on:
       - logspout
     environment:
-      - JAVA_TOOL_OPTIONS=-Xmx768m # deployment: -Xmx1086m
+      - JAVA_TOOL_OPTIONS=-Xmx768m #deployment: -Xmx1086m
     command: --server.port=80 --spring.config.additional-location=/config/
     sysctls:
       - net.ipv4.ip_unprivileged_port_start=0 # for docker < 20.03.0
-    memswap_limit: 1792m # deployment: 2432m
+    memswap_limit: 1792m #deployment: 2432m
     deploy:
       resources:
         limits:
-          memory: 1792m # deployment: 2432m
+          memory: 1792m #deployment: 2432m
 
   #just here for dev purpose, we don't want to start with this profile unless we need to.
   case-import-server:

--- a/docker-compose/study/docker-compose.override.yml
+++ b/docker-compose/study/docker-compose.override.yml
@@ -73,15 +73,15 @@ services:
     depends_on:
       - logspout
     environment:
-      - JAVA_TOOL_OPTIONS=-Xmx1408m
+      - JAVA_TOOL_OPTIONS=-Xmx384m
     command: --server.port=80 --spring.config.additional-location=/config/
     sysctls:
       - net.ipv4.ip_unprivileged_port_start=0 # for docker < 20.03.0
-    memswap_limit: 2g
+    memswap_limit: 768m
     deploy:
       resources:
         limits:
-          memory: 2g
+          memory: 768m
 
   network-modification-server:
     profiles:
@@ -378,15 +378,15 @@ services:
     depends_on:
       - logspout
     environment:
-      - JAVA_TOOL_OPTIONS=-Xmx576m
+      - JAVA_TOOL_OPTIONS=-Xmx384m
     command: --server.port=80 --spring.config.additional-location=/config/
     sysctls:
       - net.ipv4.ip_unprivileged_port_start=0 # for docker < 20.03.0
-    memswap_limit: 1g
+    memswap_limit: 768m
     deploy:
       resources:
         limits:
-          memory: 1g
+          memory: 768m
 
   sensitivity-analysis-server:
     profiles:
@@ -430,15 +430,15 @@ services:
     depends_on:
       - logspout
     environment:
-      - JAVA_TOOL_OPTIONS=-Xmx1408m
+      - JAVA_TOOL_OPTIONS=-Xmx768m
     command: --server.port=80 --spring.config.additional-location=/config/
     sysctls:
       - net.ipv4.ip_unprivileged_port_start=0 # for docker < 20.03.0
-    memswap_limit: 3g
+    memswap_limit: 1792m
     deploy:
       resources:
         limits:
-          memory: 3g
+          memory: 1792m
 
   timeseries-server:
     profiles:
@@ -482,15 +482,15 @@ services:
     depends_on:
       - logspout
     environment:
-      - JAVA_TOOL_OPTIONS=-Xmx1408m
+      - JAVA_TOOL_OPTIONS=-Xmx768m # deployment: -Xmx1408m
     command: --server.port=80 --spring.config.additional-location=/config/
     sysctls:
       - net.ipv4.ip_unprivileged_port_start=0 # for docker < 20.03.0
-    memswap_limit: 3g
+    memswap_limit: 1792m # deployment: 3072m
     deploy:
       resources:
         limits:
-          memory: 3g
+          memory: 1792m # deployment: 3072m
 
   #just here for dev purpose, we don't want to start with this profile unless we need to.
   case-import-server:
@@ -506,12 +506,12 @@ services:
     depends_on:
       - logspout
     environment:
-      - JAVA_TOOL_OPTIONS=-Xmx576m
+      - JAVA_TOOL_OPTIONS=-Xmx576m # deployment: 768m
     command: --server.port=80 --spring.config.additional-location=/config/
     sysctls:
       - net.ipv4.ip_unprivileged_port_start=0 # for docker < 20.03.0
-    memswap_limit: 1g
+    memswap_limit: 1g # deployment: 1280m
     deploy:
       resources:
         limits:
-          memory: 1g
+          memory: 1g # deployment: 1280m

--- a/docker-compose/study/docker-compose.override.yml
+++ b/docker-compose/study/docker-compose.override.yml
@@ -19,10 +19,15 @@ services:
     depends_on:
       - logspout
     environment:
-      - JAVA_TOOL_OPTIONS=-Xmx768m
+      - JAVA_TOOL_OPTIONS=-Xmx576m
     command: --server.port=80 --spring.config.additional-location=/config/
     sysctls:
       - net.ipv4.ip_unprivileged_port_start=0 # for docker < 20.03.0
+    memswap_limit: 1g
+    deploy:
+      resources:
+        limits:
+          memory: 1g
 
   geo-data-server:
     profiles:
@@ -41,10 +46,15 @@ services:
     depends_on:
       - logspout
     environment:
-      - JAVA_TOOL_OPTIONS=-Xmx768m
+      - JAVA_TOOL_OPTIONS=-Xmx576m
     command: --server.port=80 --spring.config.additional-location=/config/
     sysctls:
       - net.ipv4.ip_unprivileged_port_start=0 # for docker < 20.03.0
+    memswap_limit: 1g
+    deploy:
+      resources:
+        limits:
+          memory: 1g
 
   single-line-diagram-server:
     profiles:
@@ -63,10 +73,15 @@ services:
     depends_on:
       - logspout
     environment:
-      - JAVA_TOOL_OPTIONS=-Xmx1792m
+      - JAVA_TOOL_OPTIONS=-Xmx1408m
     command: --server.port=80 --spring.config.additional-location=/config/
     sysctls:
       - net.ipv4.ip_unprivileged_port_start=0 # for docker < 20.03.0
+    memswap_limit: 2g
+    deploy:
+      resources:
+        limits:
+          memory: 2g
 
   network-modification-server:
     profiles:
@@ -85,10 +100,15 @@ services:
     depends_on:
       - logspout
     environment:
-      - JAVA_TOOL_OPTIONS=-Xmx768m
+      - JAVA_TOOL_OPTIONS=-Xmx576m
     command: --server.port=80 --spring.config.additional-location=/config/
     sysctls:
       - net.ipv4.ip_unprivileged_port_start=0 # for docker < 20.03.0
+    memswap_limit: 1g
+    deploy:
+      resources:
+        limits:
+          memory: 1g
 
   study-notification-server:
     profiles:
@@ -107,10 +127,15 @@ services:
     depends_on:
       - logspout
     environment:
-      - JAVA_TOOL_OPTIONS=-Xmx128m
+      - JAVA_TOOL_OPTIONS=-Xmx96m
     command: --server.port=80 --spring.config.additional-location=/config/
     sysctls:
       - net.ipv4.ip_unprivileged_port_start=0 # for docker < 20.03.0
+    memswap_limit: 384m
+    deploy:
+      resources:
+        limits:
+          memory: 384m
 
   directory-notification-server:
     profiles:
@@ -129,10 +154,15 @@ services:
     depends_on:
       - logspout
     environment:
-      - JAVA_TOOL_OPTIONS=-Xmx128m
+      - JAVA_TOOL_OPTIONS=-Xmx96m
     command: --server.port=80 --spring.config.additional-location=/config/
     sysctls:
       - net.ipv4.ip_unprivileged_port_start=0 # for docker < 20.03.0
+    memswap_limit: 384m
+    deploy:
+      resources:
+        limits:
+          memory: 384m
 
   network-map-server:
     profiles:
@@ -151,10 +181,15 @@ services:
     depends_on:
       - logspout
     environment:
-      - JAVA_TOOL_OPTIONS=-Xmx768m
+      - JAVA_TOOL_OPTIONS=-Xmx576m
     command: --server.port=80 --spring.config.additional-location=/config/
     sysctls:
       - net.ipv4.ip_unprivileged_port_start=0 # for docker < 20.03.0
+    memswap_limit: 1g
+    deploy:
+      resources:
+        limits:
+          memory: 1g
 
   cgmes-gl-server:
     profiles:
@@ -171,10 +206,15 @@ services:
     depends_on:
       - logspout
     environment:
-      - JAVA_TOOL_OPTIONS=-Xmx128m
+      - JAVA_TOOL_OPTIONS=-Xmx96m
     command: --server.port=80 --spring.config.additional-location=/config/
     sysctls:
       - net.ipv4.ip_unprivileged_port_start=0 # for docker < 20.03.0
+    memswap_limit: 384m
+    deploy:
+      resources:
+        limits:
+          memory: 384m
 
   odre-server:
     profiles:
@@ -191,10 +231,15 @@ services:
     depends_on:
       - logspout
     environment:
-      - JAVA_TOOL_OPTIONS=-Xmx768m
+      - JAVA_TOOL_OPTIONS=-Xmx576m
     command: --server.port=80 --spring.config.additional-location=/config/
     sysctls:
       - net.ipv4.ip_unprivileged_port_start=0 # for docker < 20.03.0
+    memswap_limit: 1g
+    deploy:
+      resources:
+        limits:
+          memory: 1g
 
   gridstudy-app:
     profiles:
@@ -210,6 +255,11 @@ services:
       - $PWD/../env.json:/opt/bitnami/apache/htdocs/gridstudy/env.json:Z
     depends_on:
       - logspout
+    memswap_limit: 128m
+    deploy:
+      resources:
+        limits:
+          memory: 128m
 
   security-analysis-server:
     profiles:
@@ -227,10 +277,15 @@ services:
     depends_on:
       - logspout
     environment:
-      - JAVA_TOOL_OPTIONS=-Xmx768m
+      - JAVA_TOOL_OPTIONS=-Xmx1408m
     command: --server.port=80 --spring.config.additional-location=/config/
     sysctls:
       - net.ipv4.ip_unprivileged_port_start=0 # for docker < 20.03.0
+    memswap_limit: 3g
+    deploy:
+      resources:
+        limits:
+          memory: 3g
 
   dynamic-simulation-server:
     profiles:
@@ -252,6 +307,11 @@ services:
     command: --server.port=80 --spring.config.additional-location=/config/
     sysctls:
       - net.ipv4.ip_unprivileged_port_start=0 # for docker < 20.03.0
+    memswap_limit: 1792m
+    deploy:
+      resources:
+        limits:
+          memory: 1792m
 
   directory-server:
     profiles:
@@ -270,10 +330,15 @@ services:
     depends_on:
       - logspout
     environment:
-      - JAVA_TOOL_OPTIONS=-Xmx256m
+      - JAVA_TOOL_OPTIONS=-Xmx186m
     command: --server.port=80 --spring.config.additional-location=/config/
     sysctls:
       - net.ipv4.ip_unprivileged_port_start=0 # for docker < 20.03.0
+    memswap_limit: 512m
+    deploy:
+      resources:
+        limits:
+          memory: 512m
 
   gridexplore-app:
     profiles:
@@ -290,6 +355,11 @@ services:
       - $PWD/../env.json:/opt/bitnami/apache/htdocs/gridexplore/env.json:Z
     depends_on:
       - logspout
+    memswap_limit: 128m
+    deploy:
+      resources:
+        limits:
+          memory: 128m
 
   explore-server:
     profiles:
@@ -308,10 +378,15 @@ services:
     depends_on:
       - logspout
     environment:
-      - JAVA_TOOL_OPTIONS=-Xmx768m
+      - JAVA_TOOL_OPTIONS=-Xmx576m
     command: --server.port=80 --spring.config.additional-location=/config/
     sysctls:
       - net.ipv4.ip_unprivileged_port_start=0 # for docker < 20.03.0
+    memswap_limit: 1g
+    deploy:
+      resources:
+        limits:
+          memory: 1g
 
   sensitivity-analysis-server:
     profiles:
@@ -329,10 +404,15 @@ services:
     depends_on:
       - logspout
     environment:
-      - JAVA_TOOL_OPTIONS=-Xmx768m
+      - JAVA_TOOL_OPTIONS=-Xmx1408m
     command: --server.port=80 --spring.config.additional-location=/config/
     sysctls:
       - net.ipv4.ip_unprivileged_port_start=0 # for docker < 20.03.0
+    memswap_limit: 3g
+    deploy:
+      resources:
+        limits:
+          memory: 3g
 
   shortcircuit-server:
     profiles:
@@ -350,10 +430,15 @@ services:
     depends_on:
       - logspout
     environment:
-      - JAVA_TOOL_OPTIONS=-Xmx768m
+      - JAVA_TOOL_OPTIONS=-Xmx1408m
     command: --server.port=80 --spring.config.additional-location=/config/
     sysctls:
       - net.ipv4.ip_unprivileged_port_start=0 # for docker < 20.03.0
+    memswap_limit: 3g
+    deploy:
+      resources:
+        limits:
+          memory: 3g
 
   timeseries-server:
     profiles:
@@ -371,10 +456,15 @@ services:
     depends_on:
       - logspout
     environment:
-      - JAVA_TOOL_OPTIONS=-Xmx768m
+      - JAVA_TOOL_OPTIONS=-Xmx576m
     command: --server.port=80 --spring.config.additional-location=/config/
     sysctls:
       - net.ipv4.ip_unprivileged_port_start=0 # for docker < 20.03.0
+    memswap_limit: 1g
+    deploy:
+      resources:
+        limits:
+          memory: 1g
 
   voltage-init-server:
     profiles:
@@ -392,10 +482,15 @@ services:
     depends_on:
       - logspout
     environment:
-      - JAVA_TOOL_OPTIONS=-Xmx768m
+      - JAVA_TOOL_OPTIONS=-Xmx1408m
     command: --server.port=80 --spring.config.additional-location=/config/
     sysctls:
       - net.ipv4.ip_unprivileged_port_start=0 # for docker < 20.03.0
+    memswap_limit: 3g
+    deploy:
+      resources:
+        limits:
+          memory: 3g
 
   #just here for dev purpose, we don't want to start with this profile unless we need to.
   case-import-server:
@@ -411,7 +506,12 @@ services:
     depends_on:
       - logspout
     environment:
-      - JAVA_TOOL_OPTIONS=-Xmx768m
+      - JAVA_TOOL_OPTIONS=-Xmx576m
     command: --server.port=80 --spring.config.additional-location=/config/
     sysctls:
       - net.ipv4.ip_unprivileged_port_start=0 # for docker < 20.03.0
+    memswap_limit: 1g
+    deploy:
+      resources:
+        limits:
+          memory: 1g


### PR DESCRIPTION
As we are now using docker compose v2, we can use memory limits for our containers. It works similarly to Kubernetes if memory swap is prevented. 
To prevent memory swap, I use memswap_limit = deploy.resources.limits.memory (see compose-spec for more details on the values of memswap_limit or memory limits https://github.com/compose-spec/compose-spec/blob/ca5c01413d11fed0241f7726e03f6d4540ef3bb7/05-services.md?plain=1#L1295).
On my machine, after some load (running loadflow, security analysis, importing a case, displaying the logs...),  the memory used by the docker stack goes from **20G** without docker limits to **16G** with docker limits and some Xmx reductions (see below). It's around 150m memory saved by service. 
The service affected by Xmx/memory limits reductions for local development are:
- case-server (may not be possible to import TYNDP locally)
- network-store-server (may not be possible to store/retrieve big networks locally)
- network-conversion-server (may not be possible to import TYNDP locally)
- calculations services (loadflow-server, voltage-init-server, etc.). These services were already using a different Xmx than the deployment (often Xmx768m instead of Xmx1408m). I kept this.   

We could go further in reducing limits/Xmx for local development but we also need to stay balanced to avoid every developers changing these limits.

If we merge this PR, we should announce this to the developers and explain how to increase the limit where necessary as we can now have OOMKilled containers by docker.