### PR TITLE
Change sizes of some services

### DIFF
--- a/k8s/resources/study/single-line-diagram-server-deployment.yaml
+++ b/k8s/resources/study/single-line-diagram-server-deployment.yaml
@@ -7,7 +7,7 @@ metadata:
     version: "1"
     app.kubernetes.io/component: gridsuite-springboot
   annotations:
-    gridsuite.org/size: springboot-xxl
+    gridsuite.org/size: springboot-s
 spec:
   selector:
     matchLabels:

--- a/k8s/resources/study/voltage-init-server-deployment.yaml
+++ b/k8s/resources/study/voltage-init-server-deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/component: gridsuite-springboot
     gridsuite.org/springboot-with-database: "true"
   annotations:
-    gridsuite.org/size: springboot-xxl-forking
+    gridsuite.org/size: springboot-xl-forking
 spec:
   selector:
     matchLabels:


### PR DESCRIPTION
* The size of single-line-diagram-server can be changed because the voltage level limits of the NAD were not taken into account. I fixed this recently. Now that we limit the number of voltage levels to 50 instead of hundreds, the memory footprint is reduced by a lot. From testing, the s size seems to fit well.
* The size of voltage-init-server can be changed to the new size springboot-xl-forking that did not exist before. This size was tested against the previous limiting case: run one (or two parallel) voltage init calculation on a french network with a filter containing all the transformers in Parameters > Voltage Profile Initialization > Equipment Selection > Variable transformers.