### PR TITLE
Add cache-control: no-cache to apps-metadata files

### DIFF
--- a/k8s/live/azure-dev/gridapps-metadata-httpd.conf
+++ b/k8s/live/azure-dev/gridapps-metadata-httpd.conf
@@ -1,8 +1,10 @@
 # This is the base httpd.conf file of httpd:2.4 docker container, we just have added << Header set Access-Control-Allow-Origin "*" >> to the htdocs directory settings
 # and the content-type application/json to the openid-configuration file
+# and Header set Cache-Control "no-cache"
 <VirtualHost *:8080>
   DocumentRoot "/opt/bitnami/apache/htdocs"
   <Directory "/opt/bitnami/apache/htdocs">
+    Header set Cache-Control "no-cache"
     Header set Access-Control-Allow-Origin "*"
     Options Indexes FollowSymLinks
     AllowOverride All

--- a/k8s/live/azure-dev/kustomization.yaml
+++ b/k8s/live/azure-dev/kustomization.yaml
@@ -30,6 +30,7 @@ configMapGenerator:
       - openid-configuration
       - keys
   - name: apps-metadata-server-httpdconf-configmap
+    behavior: replace
     files:
       - bitnami.conf=gridapps-metadata-httpd.conf
   - name: gateway-configmap

--- a/k8s/live/azure-dev/patch_metadata_configmap.yaml
+++ b/k8s/live/azure-dev/patch_metadata_configmap.yaml
@@ -10,17 +10,3 @@
       path: .well-known/openid-configuration
     - key: authentication.json
       path: authentication.json
-- op: add
-  path: /spec/template/spec/volumes/1
-  value:
-      name: apps-metadata-server-configmap-httpdconf-volume
-      configMap:
-        name: apps-metadata-server-httpdconf-configmap
-
-- op: add
-  path: /spec/template/spec/containers/0/volumeMounts/1
-  value:
-    name: apps-metadata-server-configmap-httpdconf-volume
-    mountPath: /opt/bitnami/apache/conf/bitnami/bitnami.conf
-    subPath: bitnami.conf
-

--- a/k8s/resources/common/apps-metadata-server-deployment.yaml
+++ b/k8s/resources/common/apps-metadata-server-deployment.yaml
@@ -20,7 +20,13 @@ spec:
           volumeMounts:
             - mountPath: /opt/bitnami/apache/htdocs/
               name: apps-metadata-server-configmap-volume
+            - mountPath: /opt/bitnami/apache/conf/bitnami/bitnami.conf
+              subPath: bitnami.conf
+              name: apps-metadata-server-httpdconf-configmap-volume
       volumes:
         - name: apps-metadata-server-configmap-volume
           configMap:
             name: apps-metadata-server-configmap
+        - name: apps-metadata-server-httpdconf-configmap-volume
+          configMap:
+            name: apps-metadata-server-httpdconf-configmap

--- a/k8s/resources/common/config/apps-metadata-server/httpd.conf
+++ b/k8s/resources/common/config/apps-metadata-server/httpd.conf
@@ -1,10 +1,8 @@
-#This is the base httpd.conf file of bitname/apache:2.4 docker container, we just have added << Header set Access-Control-Allow-Origin "*" >> to the htdocs directory settings
-# and Header set Cache-Control "no-cache"
-<VirtualHost *:8080>
+#This is the base httpd.conf file of bitnami/apache:2.4 docker container, we just have added << Header set Cache-Control "no-cache" >> to the default vhost
+<VirtualHost _default_:8080>
   DocumentRoot "/opt/bitnami/apache/htdocs"
   <Directory "/opt/bitnami/apache/htdocs">
     Header set Cache-Control "no-cache"
-    Header set Access-Control-Allow-Origin "*"
     Options Indexes FollowSymLinks
     AllowOverride All
     Require all granted
@@ -13,4 +11,3 @@
   # Error Documents
   ErrorDocument 503 /503.html
 </VirtualHost>
-

--- a/k8s/resources/common/kustomization.yaml
+++ b/k8s/resources/common/kustomization.yaml
@@ -77,6 +77,9 @@ configMapGenerator:
     files:
       - config/apps-metadata.json
       - config/authentication.json
+  - name: apps-metadata-server-httpdconf-configmap
+    files:
+      - bitnami.conf=config/apps-metadata-server/httpd.conf
   - name: config-server-configmap-specific
     files:
       - application.yml=config/config-server-application.yml


### PR DESCRIPTION
Without an explicit cache-control header, because apache httpd provides the last-modified date, heuristic caching makes browsers consider the file to be fresh for a while (e.g. now+10% of last-modified-time) and no request at all is done to check if the file has changed on the server. With "no-cache", the browser must always revalidate the file (and since modern browsers and apache httpd use if-modified-since or if-none-match conditional requests, the file is most of the time used from the browser cache)