### PR TITLE
Add namespace variable and units to loadflow dashboard

### DIFF
--- a/docker-compose/technical/grafana/dashboards/loadflow_metrics.json
+++ b/docker-compose/technical/grafana/dashboards/loadflow_metrics.json
@@ -104,7 +104,8 @@
                 "value": 80
               }
             ]
-          }
+          },
+          "unit": "s"
         },
         "overrides": []
       },
@@ -131,7 +132,7 @@
         {
           "disableTextWrap": false,
           "editorMode": "builder",
-          "expr": "app_loadflow_run_seconds_max",
+          "expr": "app_loadflow_run_seconds_max{namespace=\"$namespace\", error=\"none\"}",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "instant": false,
@@ -219,7 +220,7 @@
         {
           "disableTextWrap": false,
           "editorMode": "builder",
-          "expr": "app_loadflow_run_seconds_count",
+          "expr": "app_loadflow_run_seconds_count{namespace=\"$namespace\", error=\"none\"}",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "instant": false,
@@ -280,7 +281,8 @@
                 "value": 80
               }
             ]
-          }
+          },
+          "unit": "s"
         },
         "overrides": []
       },
@@ -307,7 +309,7 @@
         {
           "disableTextWrap": false,
           "editorMode": "builder",
-          "expr": "app_loadflow_network_load_seconds_max",
+          "expr": "app_loadflow_network_load_seconds_max{namespace=\"$namespace\", error=\"none\"}",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "instant": false,
@@ -368,7 +370,8 @@
                 "value": 80
               }
             ]
-          }
+          },
+          "unit": "s"
         },
         "overrides": []
       },
@@ -395,7 +398,7 @@
         {
           "disableTextWrap": false,
           "editorMode": "builder",
-          "expr": "app_loadflow_network_save_seconds_max",
+          "expr": "app_loadflow_network_save_seconds_max{namespace=\"$namespace\", error=\"none\"}",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "instant": false,
@@ -456,7 +459,8 @@
                 "value": 80
               }
             ]
-          }
+          },
+          "unit": "s"
         },
         "overrides": []
       },
@@ -483,7 +487,7 @@
         {
           "disableTextWrap": false,
           "editorMode": "builder",
-          "expr": "app_loadflow_results_save_seconds_max",
+          "expr": "app_loadflow_results_save_seconds_max{namespace=\"$namespace\", error=\"none\"}",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "instant": false,
@@ -544,7 +548,8 @@
                 "value": 80
               }
             ]
-          }
+          },
+          "unit": "s"
         },
         "overrides": []
       },
@@ -571,7 +576,7 @@
         {
           "disableTextWrap": false,
           "editorMode": "builder",
-          "expr": "app_loadflow_report_send_seconds_max",
+          "expr": "app_loadflow_report_send_seconds_max{namespace=\"$namespace\", error=\"none\"}",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "instant": false,
@@ -632,7 +637,8 @@
                 "value": 80
               }
             ]
-          }
+          },
+          "unit": "s"
         },
         "overrides": []
       },
@@ -659,7 +665,7 @@
         {
           "disableTextWrap": false,
           "editorMode": "builder",
-          "expr": "app_loadflow_report_delete_seconds_max",
+          "expr": "app_loadflow_report_delete_seconds_max{namespace=\"$namespace\", error=\"none\"}",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "instant": false,
@@ -697,6 +703,29 @@
         "regex": "",
         "skipUrlSync": false,
         "type": "datasource"
+      },
+      {
+        "allValue": null,
+        "current": {},
+        "datasource": "${DS_PROMETHEUS}",
+        "definition": "label_values(kube_pod_info, namespace)",
+        "description": null,
+        "error": null,
+        "hide": 0,
+        "includeAll": false,
+        "label": null,
+        "multi": false,
+        "name": "namespace",
+        "options": [],
+        "query": {
+          "query": "label_values(kube_pod_info, namespace)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
       }
     ]
   },


### PR DESCRIPTION
* in the docker compose environment, namespace is "none" but the value are still displayed. Otherwise, the namespace can be selected among the list of namespace available on the cluster.
* errors are filtered, we only take the time for error="none"
* add units "seconds" to each y-axis in the dashboard, except for count