### PR TITLE
Fix authentication for local k8s instances

### DIFF
--- a/k8s/live/local/authentication.json
+++ b/k8s/live/local/authentication.json
@@ -1,0 +1,3 @@
+{
+  "authorizationCodeFlowFeatureFlag": true
+}

--- a/k8s/live/local/kustomization.yaml
+++ b/k8s/live/local/kustomization.yaml
@@ -91,6 +91,11 @@ configMapGenerator:
     files:
       - application.yml=common-application.yml
 
+  - name: apps-metadata-server-configmap
+    behavior: merge
+    files:
+      - authentication.json
+
 patches:
 - path: patches/ingresses.yaml
   target:


### PR DESCRIPTION
oidc-mock-server only works with authorization-code-flow so authentication was broken since we moved to implicit authentication.