### PR TITLE
Disable index auto-creation by ElasticSearch

### DIFF
--- a/docker-compose/technical/docker-compose.technical.yml
+++ b/docker-compose/technical/docker-compose.technical.yml
@@ -55,6 +55,7 @@ services:
       - xpack.security.enabled=false
       - ingest.geoip.downloader.enabled=false
       - ES_JAVA_OPTS=-Xms1g -Xmx1g
+      - action.auto_create_index=false
     volumes:
       - $GRIDSUITE_DATABASES/elasticsearch:/usr/share/elasticsearch/data
     restart: unless-stopped


### PR DESCRIPTION
With the configuration on main, index are recreated when using the bulk api of ElasticSearch to insert documents in the index. With this API, when the index does not exist, it's automatically created:
```
grid-elasticsearch-1  | {"@timestamp":"2024-04-25T11:27:21.887Z", "log.level": "INFO", "message":"[equipments] creating index, cause [auto(bulk api)], templates [], shards [1]/[1]", "ecs.version": "1.2.0","service.name":"ES_ECS","event.dataset":"elasticsearch.server","process.thread.name":"elasticsearch[a66319d0f89d][masterService#updateTask][T#1]","log.logger":"org.elasticsearch.cluster.metadata.MetadataCreateIndexService","elasticsearch.cluster.uuid":"MuIhLnO-RGajzcUjQB9m3A","elasticsearch.node.id":"xorR5I17QfeBm6kQxr0txw","elasticsearch.node.name":"a66319d0f89d","elasticsearch.cluster.name":"docker-cluster"}
```
This is expected and documented. This does not occur if we only read the index. The automatic index creation on the ES side only takes into account the template **in ElasticSearch** (that we do not use, as we use **Spring Data** to create our indexes!) so the index is created with default settings ignoring the settings specified on the microservice side with Spring Data. 

We have two solutions:
* keep the automatic index creation and use templating on the ElasticSearch side instead of in our microservices (https://www.elastic.co/guide/en/elasticsearch/reference/current/index-templates.html)
* disable the automatic index creation so that **Spring Data** is the only responsible for creating new indexes and not ElasticSearch.  

We chose the second option as the specific settings are easier to maintain on the microservice side in our infrastructure. This implies that the microservice responsible for the index creation need to be restarted to recreate the index (case-server, directory-server and study-server).
It would be handy to have a admin-tools script to restart these pods if we need. 