### PR TITLE
Move logstash to Kibana profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,8 +80,8 @@ _Everything described in this section is inside the folder `explicit-profiles`._
 Here's the summary of the profiles and what services they includes:
 | Component \ Service | _(none)_ | merging | study | study-light | dynamic-mapping | dynamic-simulation | suite | import | kibana | pgadmin | metrics |
 |---|---|---|---|---|---|---|---|---|---|---|---|
-| rabbitmq<br/>postgres<br/>elasticsearch<br/>logstash<br/>socat<br/>logspout | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | |
-| kibana | | | | | | | | | ✅ | | |
+| rabbitmq<br/>postgres<br/>elasticsearch | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | |
+| kibana<br/>logstash<br/>socat<br/>logspout | | | | | | | | | ✅ | | |
 | pgadmin | | | | | | | | | | ✅ | |
 | apps&#8209;metadata&#8209;server<br/>mock&#8209;user&#8209;service<br/>gateway<br/>actions&#8209;server<br/>case&#8209;server<br/>config&#8209;notification&#8209;server<br/>config&#8209;server<br/>filter&#8209;server<br/>loadflow&#8209;server<br/>network&#8209;conversion&#8209;server<br/>network&#8209;store&#8209;server<br/>report&#8209;server<br/>user&#8209;admin&#8209;server | | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | | | |
 | griddyna&#8209;app<br/>dynamic&#8209;mapping&#8209;server | | | | | ✅ | ✅ | ✅ | | | | |

--- a/docker-compose/docker-compose.base.yml
+++ b/docker-compose/docker-compose.base.yml
@@ -17,8 +17,6 @@ services:
       - $PWD/../../k8s/resources/common/config/case-server-application.yml:/config/specific/application.yml:Z
       - $PWD/../../k8s/resources/common/config/common-application.yml:/config/common/application.yml:Z
       - $GRIDSUITE_DATABASES/cases:/cases:Z
-    depends_on:
-      - logspout
     restart: unless-stopped
     environment:
       - JAVA_TOOL_OPTIONS=-Xmx576m #deployment: 768m
@@ -48,8 +46,6 @@ services:
       - $PWD/../../k8s/resources/common/config/actions-server-application.yml:/config/specific/application.yml:Z
       - $PWD/../../k8s/resources/common/config/common-application.yml:/config/common/application.yml:Z
     restart: unless-stopped
-    depends_on:
-      - logspout
     environment:
       - JAVA_TOOL_OPTIONS=-Xmx576m
     command: --server.port=80 --spring.config.additional-location=/config/
@@ -78,8 +74,6 @@ services:
       - $PWD/../../k8s/resources/common/config/filter-server-application.yml:/config/specific/application.yml:Z
       - $PWD/../../k8s/resources/common/config/common-application.yml:/config/common/application.yml:Z
     restart: unless-stopped
-    depends_on:
-      - logspout
     command: --server.port=80 --spring.config.additional-location=/config/
     sysctls:
       - net.ipv4.ip_unprivileged_port_start=0 # for docker < 20.03.0
@@ -108,8 +102,6 @@ services:
       - $PWD/../../k8s/resources/common/config/user-admin-server-application.yml:/config/specific/application.yml:Z
       - $PWD/../../k8s/resources/common/config/common-application.yml:/config/common/application.yml:Z
     restart: unless-stopped
-    depends_on:
-      - logspout
     command: --server.port=80 --spring.config.additional-location=/config/
     sysctls:
       - net.ipv4.ip_unprivileged_port_start=0 # for docker < 20.03.0
@@ -138,8 +130,6 @@ services:
       - $PWD/../../k8s/resources/common/config/report-server-application.yml:/config/specific/application.yml:Z
       - $PWD/../../k8s/resources/common/config/common-application.yml:/config/common/application.yml:Z
     restart: unless-stopped
-    depends_on:
-      - logspout
     command: --server.port=80 --spring.config.additional-location=/config/
     sysctls:
       - net.ipv4.ip_unprivileged_port_start=0 # for docker < 20.03.0
@@ -168,8 +158,6 @@ services:
       - $PWD/../../k8s/resources/common/config/network-store-server-application.yml:/config/specific/application.yml:Z
       - $PWD/../../k8s/resources/common/config/common-application.yml:/config/common/application.yml:Z
     restart: unless-stopped
-    depends_on:
-      - logspout
     environment:
       - JAVA_TOOL_OPTIONS=-Xmx1086m #deployment: 1408m
     command: --server.port=80 --spring.config.additional-location=/config/
@@ -198,8 +186,6 @@ services:
       - $PWD/../../k8s/resources/common/config/network-conversion-server-application.yml:/config/specific/application.yml:Z
       - $PWD/../../k8s/resources/common/config/common-application.yml:/config/common/application.yml:Z
     restart: unless-stopped
-    depends_on:
-      - logspout
     environment:
       - JAVA_TOOL_OPTIONS=-Xmx768m #deployment: 1408m
     command: --server.port=80 --spring.config.additional-location=/config/
@@ -229,8 +215,6 @@ services:
       - $PWD/../../k8s/resources/common/config/common-application.yml:/config/common/application.yml:Z
       - $PWD/../../k8s/resources/common/config/loadflow-server-config.yml:/home/powsybl/.itools/config.yml:Z
     restart: unless-stopped
-    depends_on:
-      - logspout
     environment:
       - JAVA_TOOL_OPTIONS=-Xmx768m #deployment: 1408m
     command: --server.port=80 --spring.config.additional-location=/config/
@@ -316,8 +300,6 @@ services:
       - $PWD/../../k8s/resources/common/config/common-application.yml:/config/common/application.yml:Z
       - $PWD/../allowed-issuers.yml:/config/allowed-issuers.yml:Z
     restart: unless-stopped
-    depends_on:
-      - logspout
     environment:
       - JAVA_TOOL_OPTIONS=-Xmx96m
     command: --server.port=80 --spring.config.additional-location=/config/
@@ -398,8 +380,6 @@ services:
       - CLIENT_REDIRECT_URI_10=http://localhost:3004/sign-in-callback
       - CLIENT_LOGOUT_REDIRECT_URI_10=http://localhost:3004/logout-callback
       - CLIENT_SILENT_REDIRECT_URI_10=http://localhost:3004/silent-renew-callback
-    depends_on:
-      - logspout
 
   apps-metadata-server:
     profiles:
@@ -419,8 +399,6 @@ services:
       - $PWD/../authentication.json:/opt/bitnami/apache/htdocs/authentication.json:Z
       - $PWD/../version.json:/opt/bitnami/apache/htdocs/version.json:Z
       - $PWD/../gridapps-metadata-httpd.conf:/opt/bitnami/apache/conf/bitnami/bitnami.conf:Z
-    depends_on:
-      - logspout
     memswap_limit: 128m
     deploy:
       resources:

--- a/docker-compose/docker-compose.base.yml
+++ b/docker-compose/docker-compose.base.yml
@@ -17,6 +17,10 @@ services:
       - $PWD/../../k8s/resources/common/config/case-server-application.yml:/config/specific/application.yml:Z
       - $PWD/../../k8s/resources/common/config/common-application.yml:/config/common/application.yml:Z
       - $GRIDSUITE_DATABASES/cases:/cases:Z
+    depends_on:
+      logspout:
+        condition: "service_started"
+        required: false
     restart: unless-stopped
     environment:
       - JAVA_TOOL_OPTIONS=-Xmx576m #deployment: 768m
@@ -46,6 +50,10 @@ services:
       - $PWD/../../k8s/resources/common/config/actions-server-application.yml:/config/specific/application.yml:Z
       - $PWD/../../k8s/resources/common/config/common-application.yml:/config/common/application.yml:Z
     restart: unless-stopped
+    depends_on:
+      logspout:
+        condition: "service_started"
+        required: false
     environment:
       - JAVA_TOOL_OPTIONS=-Xmx576m
     command: --server.port=80 --spring.config.additional-location=/config/
@@ -74,6 +82,10 @@ services:
       - $PWD/../../k8s/resources/common/config/filter-server-application.yml:/config/specific/application.yml:Z
       - $PWD/../../k8s/resources/common/config/common-application.yml:/config/common/application.yml:Z
     restart: unless-stopped
+    depends_on:
+      logspout:
+        condition: "service_started"
+        required: false
     command: --server.port=80 --spring.config.additional-location=/config/
     sysctls:
       - net.ipv4.ip_unprivileged_port_start=0 # for docker < 20.03.0
@@ -102,6 +114,10 @@ services:
       - $PWD/../../k8s/resources/common/config/user-admin-server-application.yml:/config/specific/application.yml:Z
       - $PWD/../../k8s/resources/common/config/common-application.yml:/config/common/application.yml:Z
     restart: unless-stopped
+    depends_on:
+      logspout:
+        condition: "service_started"
+        required: false
     command: --server.port=80 --spring.config.additional-location=/config/
     sysctls:
       - net.ipv4.ip_unprivileged_port_start=0 # for docker < 20.03.0
@@ -130,6 +146,10 @@ services:
       - $PWD/../../k8s/resources/common/config/report-server-application.yml:/config/specific/application.yml:Z
       - $PWD/../../k8s/resources/common/config/common-application.yml:/config/common/application.yml:Z
     restart: unless-stopped
+    depends_on:
+      logspout:
+        condition: "service_started"
+        required: false
     command: --server.port=80 --spring.config.additional-location=/config/
     sysctls:
       - net.ipv4.ip_unprivileged_port_start=0 # for docker < 20.03.0
@@ -158,6 +178,10 @@ services:
       - $PWD/../../k8s/resources/common/config/network-store-server-application.yml:/config/specific/application.yml:Z
       - $PWD/../../k8s/resources/common/config/common-application.yml:/config/common/application.yml:Z
     restart: unless-stopped
+    depends_on:
+      logspout:
+        condition: "service_started"
+        required: false
     environment:
       - JAVA_TOOL_OPTIONS=-Xmx1086m #deployment: 1408m
     command: --server.port=80 --spring.config.additional-location=/config/
@@ -186,6 +210,10 @@ services:
       - $PWD/../../k8s/resources/common/config/network-conversion-server-application.yml:/config/specific/application.yml:Z
       - $PWD/../../k8s/resources/common/config/common-application.yml:/config/common/application.yml:Z
     restart: unless-stopped
+    depends_on:
+      logspout:
+        condition: "service_started"
+        required: false
     environment:
       - JAVA_TOOL_OPTIONS=-Xmx768m #deployment: 1408m
     command: --server.port=80 --spring.config.additional-location=/config/
@@ -215,6 +243,10 @@ services:
       - $PWD/../../k8s/resources/common/config/common-application.yml:/config/common/application.yml:Z
       - $PWD/../../k8s/resources/common/config/loadflow-server-config.yml:/home/powsybl/.itools/config.yml:Z
     restart: unless-stopped
+    depends_on:
+      logspout:
+        condition: "service_started"
+        required: false
     environment:
       - JAVA_TOOL_OPTIONS=-Xmx768m #deployment: 1408m
     command: --server.port=80 --spring.config.additional-location=/config/
@@ -300,6 +332,10 @@ services:
       - $PWD/../../k8s/resources/common/config/common-application.yml:/config/common/application.yml:Z
       - $PWD/../allowed-issuers.yml:/config/allowed-issuers.yml:Z
     restart: unless-stopped
+    depends_on:
+      logspout:
+        condition: "service_started"
+        required: false
     environment:
       - JAVA_TOOL_OPTIONS=-Xmx96m
     command: --server.port=80 --spring.config.additional-location=/config/
@@ -380,6 +416,10 @@ services:
       - CLIENT_REDIRECT_URI_10=http://localhost:3004/sign-in-callback
       - CLIENT_LOGOUT_REDIRECT_URI_10=http://localhost:3004/logout-callback
       - CLIENT_SILENT_REDIRECT_URI_10=http://localhost:3004/silent-renew-callback
+    depends_on:
+      logspout:
+        condition: "service_started"
+        required: false
 
   apps-metadata-server:
     profiles:
@@ -399,6 +439,10 @@ services:
       - $PWD/../authentication.json:/opt/bitnami/apache/htdocs/authentication.json:Z
       - $PWD/../version.json:/opt/bitnami/apache/htdocs/version.json:Z
       - $PWD/../gridapps-metadata-httpd.conf:/opt/bitnami/apache/conf/bitnami/bitnami.conf:Z
+    depends_on:
+      logspout:
+        condition: "service_started"
+        required: false
     memswap_limit: 128m
     deploy:
       resources:

--- a/docker-compose/dynamic-mapping/docker-compose.override.yml
+++ b/docker-compose/dynamic-mapping/docker-compose.override.yml
@@ -13,8 +13,6 @@ services:
     volumes:
       - $PWD/../dynamic-mapping/griddyna-app-idpSettings.json:/opt/bitnami/apache/htdocs/griddyna/idpSettings.json:Z
       - $PWD/../env.json:/opt/bitnami/apache/htdocs/griddyna/env.json:Z
-    depends_on:
-      - logspout
     memswap_limit: 128m
     deploy:
       resources:
@@ -34,8 +32,6 @@ services:
       - $PWD/../../k8s/resources/dynamic-mapping/config/dynamic-mapping-server-application.yml:/config/specific/application.yml:Z
       - $PWD/../../k8s/resources/common/config/common-application.yml:/config/common/application.yml:Z
     restart: unless-stopped
-    depends_on:
-      - logspout
     environment:
       - JAVA_TOOL_OPTIONS=-Xmx576m
     command: --server.port=80 --spring.config.additional-location=/config/

--- a/docker-compose/dynamic-mapping/docker-compose.override.yml
+++ b/docker-compose/dynamic-mapping/docker-compose.override.yml
@@ -13,6 +13,10 @@ services:
     volumes:
       - $PWD/../dynamic-mapping/griddyna-app-idpSettings.json:/opt/bitnami/apache/htdocs/griddyna/idpSettings.json:Z
       - $PWD/../env.json:/opt/bitnami/apache/htdocs/griddyna/env.json:Z
+    depends_on:
+      logspout:
+        condition: "service_started"
+        required: false
     memswap_limit: 128m
     deploy:
       resources:
@@ -32,6 +36,10 @@ services:
       - $PWD/../../k8s/resources/dynamic-mapping/config/dynamic-mapping-server-application.yml:/config/specific/application.yml:Z
       - $PWD/../../k8s/resources/common/config/common-application.yml:/config/common/application.yml:Z
     restart: unless-stopped
+    depends_on:
+      logspout:
+        condition: "service_started"
+        required: false
     environment:
       - JAVA_TOOL_OPTIONS=-Xmx576m
     command: --server.port=80 --spring.config.additional-location=/config/

--- a/docker-compose/merging/docker-compose.override.yml
+++ b/docker-compose/merging/docker-compose.override.yml
@@ -13,6 +13,10 @@ services:
       - $PWD/../../k8s/resources/merging/config/merge-orchestrator-server-application.yml:/config/specific/application.yml:Z
       - $PWD/../../k8s/resources/common/config/common-application.yml:/config/common/application.yml:Z
     restart: unless-stopped
+    depends_on:
+      logspout:
+        condition: "service_started"
+        required: false
     environment:
       - JAVA_TOOL_OPTIONS=-Xmx576m
     command: --server.port=80 --spring.config.additional-location=/config/
@@ -35,6 +39,10 @@ services:
     volumes:
       - $PWD/../../k8s/resources/merging/config/merge-notification-server-application.yml:/config/specific/application.yml:Z
       - $PWD/../../k8s/resources/common/config/common-application.yml:/config/common/application.yml:Z
+    depends_on:
+      logspout:
+        condition: "service_started"
+        required: false
     environment:
       - JAVA_TOOL_OPTIONS=-Xmx96m
     command: --server.port=80 --spring.config.additional-location=/config/
@@ -58,6 +66,10 @@ services:
       - $PWD/../../k8s/resources/merging/config/balances-adjustment-server-application.yml:/config/specific/application.yml:Z
       - $PWD/../../k8s/resources/common/config/common-application.yml:/config/common/application.yml:Z
       - $PWD/../../k8s/resources/merging/config/balances-adjustment-server-config.yml:/home/powsybl/.itools/config.yml:Z
+    depends_on:
+      logspout:
+        condition: "service_started"
+        required: false
     environment:
       - JAVA_TOOL_OPTIONS=-Xmx576m
     command: --server.port=80 --spring.config.additional-location=/config/
@@ -80,6 +92,10 @@ services:
     volumes:
       - $PWD/../../k8s/resources/merging/config/case-validation-server-application.yml:/config/specific/application.yml:Z
       - $PWD/../../k8s/resources/common/config/common-application.yml:/config/common/application.yml:Z
+    depends_on:
+      logspout:
+        condition: "service_started"
+        required: false
     environment:
       - JAVA_TOOL_OPTIONS=-Xmx96m
     command: --server.port=80 --spring.config.additional-location=/config/
@@ -103,6 +119,10 @@ services:
       - $PWD/../../k8s/resources/merging/config/cgmes-boundary-server-application.yml:/config/specific/application.yml:Z
       - $PWD/../../k8s/resources/common/config/common-application.yml:/config/common/application.yml:Z
     restart: unless-stopped
+    depends_on:
+      logspout:
+        condition: "service_started"
+        required: false
     environment:
       - JAVA_TOOL_OPTIONS=-Xmx96m
     command: --server.port=80 --spring.config.additional-location=/config/
@@ -130,6 +150,10 @@ services:
       - $PWD/../../k8s/resources/merging/config/case-import-job-application.yml:/config/specific/application.yml:Z
       - $PWD/../merging/case-import-job/case-import-job-config.yml:/root/.itools/config.yml:Z
       - $PWD/../../k8s/resources/common/config/common-application.yml:/config/common/application.yml:Z
+    depends_on:
+      logspout:
+        condition: "service_started"
+        required: false
     sysctls:
       - net.ipv4.ip_unprivileged_port_start=0 # for docker < 20.03.0
 
@@ -149,6 +173,10 @@ services:
       - $PWD/../../k8s/resources/merging/config/cgmes-assembling-job-application.yml:/config/specific/application.yml:Z
       - $PWD/../merging/cgmes-assembling-job/cgmes-assembling-job-config.yml:/root/.itools/config.yml:Z
       - $PWD/../../k8s/resources/common/config/common-application.yml:/config/common/application.yml:Z
+    depends_on:
+      logspout:
+        condition: "service_started"
+        required: false
     sysctls:
       - net.ipv4.ip_unprivileged_port_start=0 # for docker < 20.03.0
 
@@ -163,6 +191,10 @@ services:
     volumes:
       - $PWD/../merging/gridmerge-app-idpSettings.json:/opt/bitnami/apache/htdocs/gridmerge/idpSettings.json:Z
       - $PWD/../env.json:/opt/bitnami/apache/htdocs/gridmerge/env.json:Z
+    depends_on:
+      logspout:
+        condition: "service_started"
+        required: false
     memswap_limit: 128m
     deploy:
       resources:

--- a/docker-compose/merging/docker-compose.override.yml
+++ b/docker-compose/merging/docker-compose.override.yml
@@ -13,8 +13,6 @@ services:
       - $PWD/../../k8s/resources/merging/config/merge-orchestrator-server-application.yml:/config/specific/application.yml:Z
       - $PWD/../../k8s/resources/common/config/common-application.yml:/config/common/application.yml:Z
     restart: unless-stopped
-    depends_on:
-      - logspout
     environment:
       - JAVA_TOOL_OPTIONS=-Xmx576m
     command: --server.port=80 --spring.config.additional-location=/config/
@@ -37,8 +35,6 @@ services:
     volumes:
       - $PWD/../../k8s/resources/merging/config/merge-notification-server-application.yml:/config/specific/application.yml:Z
       - $PWD/../../k8s/resources/common/config/common-application.yml:/config/common/application.yml:Z
-    depends_on:
-      - logspout
     environment:
       - JAVA_TOOL_OPTIONS=-Xmx96m
     command: --server.port=80 --spring.config.additional-location=/config/
@@ -62,8 +58,6 @@ services:
       - $PWD/../../k8s/resources/merging/config/balances-adjustment-server-application.yml:/config/specific/application.yml:Z
       - $PWD/../../k8s/resources/common/config/common-application.yml:/config/common/application.yml:Z
       - $PWD/../../k8s/resources/merging/config/balances-adjustment-server-config.yml:/home/powsybl/.itools/config.yml:Z
-    depends_on:
-      - logspout
     environment:
       - JAVA_TOOL_OPTIONS=-Xmx576m
     command: --server.port=80 --spring.config.additional-location=/config/
@@ -86,8 +80,6 @@ services:
     volumes:
       - $PWD/../../k8s/resources/merging/config/case-validation-server-application.yml:/config/specific/application.yml:Z
       - $PWD/../../k8s/resources/common/config/common-application.yml:/config/common/application.yml:Z
-    depends_on:
-      - logspout
     environment:
       - JAVA_TOOL_OPTIONS=-Xmx96m
     command: --server.port=80 --spring.config.additional-location=/config/
@@ -111,8 +103,6 @@ services:
       - $PWD/../../k8s/resources/merging/config/cgmes-boundary-server-application.yml:/config/specific/application.yml:Z
       - $PWD/../../k8s/resources/common/config/common-application.yml:/config/common/application.yml:Z
     restart: unless-stopped
-    depends_on:
-      - logspout
     environment:
       - JAVA_TOOL_OPTIONS=-Xmx96m
     command: --server.port=80 --spring.config.additional-location=/config/
@@ -140,8 +130,6 @@ services:
       - $PWD/../../k8s/resources/merging/config/case-import-job-application.yml:/config/specific/application.yml:Z
       - $PWD/../merging/case-import-job/case-import-job-config.yml:/root/.itools/config.yml:Z
       - $PWD/../../k8s/resources/common/config/common-application.yml:/config/common/application.yml:Z
-    depends_on:
-      - logspout
     sysctls:
       - net.ipv4.ip_unprivileged_port_start=0 # for docker < 20.03.0
 
@@ -161,8 +149,6 @@ services:
       - $PWD/../../k8s/resources/merging/config/cgmes-assembling-job-application.yml:/config/specific/application.yml:Z
       - $PWD/../merging/cgmes-assembling-job/cgmes-assembling-job-config.yml:/root/.itools/config.yml:Z
       - $PWD/../../k8s/resources/common/config/common-application.yml:/config/common/application.yml:Z
-    depends_on:
-      - logspout
     sysctls:
       - net.ipv4.ip_unprivileged_port_start=0 # for docker < 20.03.0
 
@@ -177,8 +163,6 @@ services:
     volumes:
       - $PWD/../merging/gridmerge-app-idpSettings.json:/opt/bitnami/apache/htdocs/gridmerge/idpSettings.json:Z
       - $PWD/../env.json:/opt/bitnami/apache/htdocs/gridmerge/env.json:Z
-    depends_on:
-      - logspout
     memswap_limit: 128m
     deploy:
       resources:

--- a/docker-compose/study/docker-compose.override.yml
+++ b/docker-compose/study/docker-compose.override.yml
@@ -15,6 +15,10 @@ services:
       - $PWD/../../k8s/resources/study/config/study-server-application.yml:/config/specific/application.yml:Z
       - $PWD/../../k8s/resources/common/config/common-application.yml:/config/common/application.yml:Z
     restart: unless-stopped
+    depends_on:
+      logspout:
+        condition: "service_started"
+        required: false
     environment:
       - JAVA_TOOL_OPTIONS=-Xmx576m
     command: --server.port=80 --spring.config.additional-location=/config/
@@ -40,6 +44,10 @@ services:
       - $PWD/../../k8s/resources/study/config/geo-data-server-application.yml:/config/specific/application.yml:Z
       - $PWD/../../k8s/resources/common/config/common-application.yml:/config/common/application.yml:Z
     restart: unless-stopped
+    depends_on:
+      logspout:
+        condition: "service_started"
+        required: false
     environment:
       - JAVA_TOOL_OPTIONS=-Xmx576m
     command: --server.port=80 --spring.config.additional-location=/config/
@@ -65,6 +73,10 @@ services:
       - $PWD/../../k8s/resources/study/config/single-line-diagram-server-application.yml:/config/specific/application.yml:Z
       - $PWD/../../k8s/resources/common/config/common-application.yml:/config/common/application.yml:Z
     restart: unless-stopped
+    depends_on:
+      logspout:
+        condition: "service_started"
+        required: false
     environment:
       - JAVA_TOOL_OPTIONS=-Xmx384m #deployment: 576m
     command: --server.port=80 --spring.config.additional-location=/config/
@@ -90,6 +102,10 @@ services:
       - $PWD/../../k8s/resources/study/config/network-modification-server-application.yml:/config/specific/application.yml:Z
       - $PWD/../../k8s/resources/common/config/common-application.yml:/config/common/application.yml:Z
     restart: unless-stopped
+    depends_on:
+      logspout:
+        condition: "service_started"
+        required: false
     environment:
       - JAVA_TOOL_OPTIONS=-Xmx576m
     command: --server.port=80 --spring.config.additional-location=/config/
@@ -115,6 +131,10 @@ services:
       - $PWD/../../k8s/resources/study/config/study-notification-server-application.yml:/config/specific/application.yml:Z
       - $PWD/../../k8s/resources/common/config/common-application.yml:/config/common/application.yml:Z
     restart: unless-stopped
+    depends_on:
+      logspout:
+        condition: "service_started"
+        required: false
     environment:
       - JAVA_TOOL_OPTIONS=-Xmx96m
     command: --server.port=80 --spring.config.additional-location=/config/
@@ -140,6 +160,10 @@ services:
       - $PWD/../../k8s/resources/study/config/directory-notification-server-application.yml:/config/specific/application.yml:Z
       - $PWD/../../k8s/resources/common/config/common-application.yml:/config/common/application.yml:Z
     restart: unless-stopped
+    depends_on:
+      logspout:
+        condition: "service_started"
+        required: false
     environment:
       - JAVA_TOOL_OPTIONS=-Xmx96m
     command: --server.port=80 --spring.config.additional-location=/config/
@@ -165,6 +189,10 @@ services:
       - $PWD/../../k8s/resources/study/config/network-map-server-application.yml:/config/specific/application.yml:Z
       - $PWD/../../k8s/resources/common/config/common-application.yml:/config/common/application.yml:Z
     restart: unless-stopped
+    depends_on:
+      logspout:
+        condition: "service_started"
+        required: false
     environment:
       - JAVA_TOOL_OPTIONS=-Xmx576m #deployment: 768m
     command: --server.port=80 --spring.config.additional-location=/config/
@@ -188,6 +216,10 @@ services:
       - $PWD/../../k8s/resources/study/config/cgmes-gl-server-application.yml:/config/specific/application.yml:Z
       - $PWD/../../k8s/resources/common/config/common-application.yml:/config/common/application.yml:Z
     restart: unless-stopped
+    depends_on:
+      logspout:
+        condition: "service_started"
+        required: false
     environment:
       - JAVA_TOOL_OPTIONS=-Xmx96m
     command: --server.port=80 --spring.config.additional-location=/config/
@@ -211,6 +243,10 @@ services:
       - $PWD/../../k8s/resources/study/config/odre-server-application.yml:/config/specific/application.yml:Z
       - $PWD/../../k8s/resources/common/config/common-application.yml:/config/common/application.yml:Z
     restart: unless-stopped
+    depends_on:
+      logspout:
+        condition: "service_started"
+        required: false
     environment:
       - JAVA_TOOL_OPTIONS=-Xmx768m
     command: --server.port=80 --spring.config.additional-location=/config/
@@ -234,6 +270,10 @@ services:
     volumes:
       - $PWD/../study/gridstudy-app-idpSettings.json:/opt/bitnami/apache/htdocs/gridstudy/idpSettings.json:Z
       - $PWD/../env.json:/opt/bitnami/apache/htdocs/gridstudy/env.json:Z
+    depends_on:
+      logspout:
+        condition: "service_started"
+        required: false
     memswap_limit: 128m
     deploy:
       resources:
@@ -253,6 +293,10 @@ services:
       - $PWD/../../k8s/resources/common/config/common-application.yml:/config/common/application.yml:Z
       - $PWD/../../k8s/resources/study/config/security-analysis-server-config.yml:/home/powsybl/.itools/config.yml:Z
     restart: unless-stopped
+    depends_on:
+      logspout:
+        condition: "service_started"
+        required: false
     environment:
       - JAVA_TOOL_OPTIONS=-Xmx768m #deployment: 1408m
     command: --server.port=80 --spring.config.additional-location=/config/
@@ -304,6 +348,10 @@ services:
       - $PWD/../../k8s/resources/study/config/directory-server-application.yml:/config/specific/application.yml:Z
       - $PWD/../../k8s/resources/common/config/common-application.yml:/config/common/application.yml:Z
     restart: unless-stopped
+    depends_on:
+      logspout:
+        condition: "service_started"
+        required: false
     environment:
       - JAVA_TOOL_OPTIONS=-Xmx186m # not used by the native image
     command: --server.port=80 --spring.config.additional-location=/config/
@@ -328,6 +376,10 @@ services:
     volumes:
       - $PWD/../study/gridexplore-app-idpSettings.json:/opt/bitnami/apache/htdocs/gridexplore/idpSettings.json:Z
       - $PWD/../env.json:/opt/bitnami/apache/htdocs/gridexplore/env.json:Z
+    depends_on:
+      logspout:
+        condition: "service_started"
+        required: false
     memswap_limit: 128m
     deploy:
       resources:
@@ -348,6 +400,10 @@ services:
       - $PWD/../../k8s/resources/study/config/explore-server-application.yml:/config/specific/application.yml:Z
       - $PWD/../../k8s/resources/common/config/common-application.yml:/config/common/application.yml:Z
     restart: unless-stopped
+    depends_on:
+      logspout:
+        condition: "service_started"
+        required: false
     environment:
       - JAVA_TOOL_OPTIONS=-Xmx384m
     command: --server.port=80 --spring.config.additional-location=/config/
@@ -372,6 +428,10 @@ services:
       - $PWD/../../k8s/resources/common/config/common-application.yml:/config/common/application.yml:Z
       - $PWD/../../k8s/resources/study/config/sensitivity-analysis-server-config.yml:/home/powsybl/.itools/config.yml:Z
     restart: unless-stopped
+    depends_on:
+      logspout:
+        condition: "service_started"
+        required: false
     environment:
       - JAVA_TOOL_OPTIONS=-Xmx768m #deployment: 1408m
     command: --server.port=80 --spring.config.additional-location=/config/
@@ -396,6 +456,10 @@ services:
       - $PWD/../../k8s/resources/common/config/common-application.yml:/config/common/application.yml:Z
       - $PWD/../../k8s/resources/study/config/shortcircuit-server-config.yml:/home/powsybl/.itools/config.yml:Z
     restart: unless-stopped
+    depends_on:
+      logspout:
+        condition: "service_started"
+        required: false
     environment:
       - JAVA_TOOL_OPTIONS=-Xmx768m
     command: --server.port=80 --spring.config.additional-location=/config/
@@ -420,6 +484,10 @@ services:
       - $PWD/../../k8s/resources/study/config/timeseries-server-application.yml:/config/specific/application.yml:Z
       - $PWD/../../k8s/resources/common/config/common-application.yml:/config/common/application.yml:Z
     restart: unless-stopped
+    depends_on:
+      logspout:
+        condition: "service_started"
+        required: false
     environment:
       - JAVA_TOOL_OPTIONS=-Xmx576m
     command: --server.port=80 --spring.config.additional-location=/config/
@@ -444,6 +512,10 @@ services:
       - $PWD/../../k8s/resources/common/config/common-application.yml:/config/common/application.yml:Z
       - $PWD/../../k8s/resources/study/config/voltage-init-server-config.yml:/home/powsybl/.itools/config.yml:Z
     restart: unless-stopped
+    depends_on:
+      logspout:
+        condition: "service_started"
+        required: false
     environment:
       - JAVA_TOOL_OPTIONS=-Xmx768m #deployment: -Xmx1086m
     command: --server.port=80 --spring.config.additional-location=/config/
@@ -466,6 +538,10 @@ services:
     volumes:
       - $PWD/../../k8s/resources/common/config/common-application.yml:/config/common/application.yml:Z
     restart: unless-stopped
+    depends_on:
+      logspout:
+        condition: "service_started"
+        required: false
     environment:
       - JAVA_TOOL_OPTIONS=-Xmx96m
     command: --server.port=80 --spring.config.additional-location=/config/
@@ -488,6 +564,10 @@ services:
     volumes:
       - $PWD/../study/gridadmin-app-idpSettings.json:/opt/bitnami/apache/htdocs/gridadmin/idpSettings.json:Z
       - $PWD/../env.json:/opt/bitnami/apache/htdocs/gridadmin/env.json:Z
+    depends_on:
+      logspout:
+        condition: "service_started"
+        required: false
     memswap_limit: 128m
     deploy:
       resources:

--- a/docker-compose/study/docker-compose.override.yml
+++ b/docker-compose/study/docker-compose.override.yml
@@ -15,8 +15,6 @@ services:
       - $PWD/../../k8s/resources/study/config/study-server-application.yml:/config/specific/application.yml:Z
       - $PWD/../../k8s/resources/common/config/common-application.yml:/config/common/application.yml:Z
     restart: unless-stopped
-    depends_on:
-      - logspout
     environment:
       - JAVA_TOOL_OPTIONS=-Xmx576m
     command: --server.port=80 --spring.config.additional-location=/config/
@@ -42,8 +40,6 @@ services:
       - $PWD/../../k8s/resources/study/config/geo-data-server-application.yml:/config/specific/application.yml:Z
       - $PWD/../../k8s/resources/common/config/common-application.yml:/config/common/application.yml:Z
     restart: unless-stopped
-    depends_on:
-      - logspout
     environment:
       - JAVA_TOOL_OPTIONS=-Xmx576m
     command: --server.port=80 --spring.config.additional-location=/config/
@@ -69,8 +65,6 @@ services:
       - $PWD/../../k8s/resources/study/config/single-line-diagram-server-application.yml:/config/specific/application.yml:Z
       - $PWD/../../k8s/resources/common/config/common-application.yml:/config/common/application.yml:Z
     restart: unless-stopped
-    depends_on:
-      - logspout
     environment:
       - JAVA_TOOL_OPTIONS=-Xmx384m #deployment: 576m
     command: --server.port=80 --spring.config.additional-location=/config/
@@ -96,8 +90,6 @@ services:
       - $PWD/../../k8s/resources/study/config/network-modification-server-application.yml:/config/specific/application.yml:Z
       - $PWD/../../k8s/resources/common/config/common-application.yml:/config/common/application.yml:Z
     restart: unless-stopped
-    depends_on:
-      - logspout
     environment:
       - JAVA_TOOL_OPTIONS=-Xmx576m
     command: --server.port=80 --spring.config.additional-location=/config/
@@ -123,8 +115,6 @@ services:
       - $PWD/../../k8s/resources/study/config/study-notification-server-application.yml:/config/specific/application.yml:Z
       - $PWD/../../k8s/resources/common/config/common-application.yml:/config/common/application.yml:Z
     restart: unless-stopped
-    depends_on:
-      - logspout
     environment:
       - JAVA_TOOL_OPTIONS=-Xmx96m
     command: --server.port=80 --spring.config.additional-location=/config/
@@ -150,8 +140,6 @@ services:
       - $PWD/../../k8s/resources/study/config/directory-notification-server-application.yml:/config/specific/application.yml:Z
       - $PWD/../../k8s/resources/common/config/common-application.yml:/config/common/application.yml:Z
     restart: unless-stopped
-    depends_on:
-      - logspout
     environment:
       - JAVA_TOOL_OPTIONS=-Xmx96m
     command: --server.port=80 --spring.config.additional-location=/config/
@@ -177,8 +165,6 @@ services:
       - $PWD/../../k8s/resources/study/config/network-map-server-application.yml:/config/specific/application.yml:Z
       - $PWD/../../k8s/resources/common/config/common-application.yml:/config/common/application.yml:Z
     restart: unless-stopped
-    depends_on:
-      - logspout
     environment:
       - JAVA_TOOL_OPTIONS=-Xmx576m #deployment: 768m
     command: --server.port=80 --spring.config.additional-location=/config/
@@ -202,8 +188,6 @@ services:
       - $PWD/../../k8s/resources/study/config/cgmes-gl-server-application.yml:/config/specific/application.yml:Z
       - $PWD/../../k8s/resources/common/config/common-application.yml:/config/common/application.yml:Z
     restart: unless-stopped
-    depends_on:
-      - logspout
     environment:
       - JAVA_TOOL_OPTIONS=-Xmx96m
     command: --server.port=80 --spring.config.additional-location=/config/
@@ -227,8 +211,6 @@ services:
       - $PWD/../../k8s/resources/study/config/odre-server-application.yml:/config/specific/application.yml:Z
       - $PWD/../../k8s/resources/common/config/common-application.yml:/config/common/application.yml:Z
     restart: unless-stopped
-    depends_on:
-      - logspout
     environment:
       - JAVA_TOOL_OPTIONS=-Xmx768m
     command: --server.port=80 --spring.config.additional-location=/config/
@@ -252,8 +234,6 @@ services:
     volumes:
       - $PWD/../study/gridstudy-app-idpSettings.json:/opt/bitnami/apache/htdocs/gridstudy/idpSettings.json:Z
       - $PWD/../env.json:/opt/bitnami/apache/htdocs/gridstudy/env.json:Z
-    depends_on:
-      - logspout
     memswap_limit: 128m
     deploy:
       resources:
@@ -273,8 +253,6 @@ services:
       - $PWD/../../k8s/resources/common/config/common-application.yml:/config/common/application.yml:Z
       - $PWD/../../k8s/resources/study/config/security-analysis-server-config.yml:/home/powsybl/.itools/config.yml:Z
     restart: unless-stopped
-    depends_on:
-      - logspout
     environment:
       - JAVA_TOOL_OPTIONS=-Xmx768m #deployment: 1408m
     command: --server.port=80 --spring.config.additional-location=/config/
@@ -326,8 +304,6 @@ services:
       - $PWD/../../k8s/resources/study/config/directory-server-application.yml:/config/specific/application.yml:Z
       - $PWD/../../k8s/resources/common/config/common-application.yml:/config/common/application.yml:Z
     restart: unless-stopped
-    depends_on:
-      - logspout
     environment:
       - JAVA_TOOL_OPTIONS=-Xmx186m # not used by the native image
     command: --server.port=80 --spring.config.additional-location=/config/
@@ -352,8 +328,6 @@ services:
     volumes:
       - $PWD/../study/gridexplore-app-idpSettings.json:/opt/bitnami/apache/htdocs/gridexplore/idpSettings.json:Z
       - $PWD/../env.json:/opt/bitnami/apache/htdocs/gridexplore/env.json:Z
-    depends_on:
-      - logspout
     memswap_limit: 128m
     deploy:
       resources:
@@ -374,8 +348,6 @@ services:
       - $PWD/../../k8s/resources/study/config/explore-server-application.yml:/config/specific/application.yml:Z
       - $PWD/../../k8s/resources/common/config/common-application.yml:/config/common/application.yml:Z
     restart: unless-stopped
-    depends_on:
-      - logspout
     environment:
       - JAVA_TOOL_OPTIONS=-Xmx384m
     command: --server.port=80 --spring.config.additional-location=/config/
@@ -400,8 +372,6 @@ services:
       - $PWD/../../k8s/resources/common/config/common-application.yml:/config/common/application.yml:Z
       - $PWD/../../k8s/resources/study/config/sensitivity-analysis-server-config.yml:/home/powsybl/.itools/config.yml:Z
     restart: unless-stopped
-    depends_on:
-      - logspout
     environment:
       - JAVA_TOOL_OPTIONS=-Xmx768m #deployment: 1408m
     command: --server.port=80 --spring.config.additional-location=/config/
@@ -426,8 +396,6 @@ services:
       - $PWD/../../k8s/resources/common/config/common-application.yml:/config/common/application.yml:Z
       - $PWD/../../k8s/resources/study/config/shortcircuit-server-config.yml:/home/powsybl/.itools/config.yml:Z
     restart: unless-stopped
-    depends_on:
-      - logspout
     environment:
       - JAVA_TOOL_OPTIONS=-Xmx768m
     command: --server.port=80 --spring.config.additional-location=/config/
@@ -452,8 +420,6 @@ services:
       - $PWD/../../k8s/resources/study/config/timeseries-server-application.yml:/config/specific/application.yml:Z
       - $PWD/../../k8s/resources/common/config/common-application.yml:/config/common/application.yml:Z
     restart: unless-stopped
-    depends_on:
-      - logspout
     environment:
       - JAVA_TOOL_OPTIONS=-Xmx576m
     command: --server.port=80 --spring.config.additional-location=/config/
@@ -478,8 +444,6 @@ services:
       - $PWD/../../k8s/resources/common/config/common-application.yml:/config/common/application.yml:Z
       - $PWD/../../k8s/resources/study/config/voltage-init-server-config.yml:/home/powsybl/.itools/config.yml:Z
     restart: unless-stopped
-    depends_on:
-      - logspout
     environment:
       - JAVA_TOOL_OPTIONS=-Xmx768m #deployment: -Xmx1086m
     command: --server.port=80 --spring.config.additional-location=/config/
@@ -502,8 +466,6 @@ services:
     volumes:
       - $PWD/../../k8s/resources/common/config/common-application.yml:/config/common/application.yml:Z
     restart: unless-stopped
-    depends_on:
-      - logspout
     environment:
       - JAVA_TOOL_OPTIONS=-Xmx96m
     command: --server.port=80 --spring.config.additional-location=/config/
@@ -526,8 +488,6 @@ services:
     volumes:
       - $PWD/../study/gridadmin-app-idpSettings.json:/opt/bitnami/apache/htdocs/gridadmin/idpSettings.json:Z
       - $PWD/../env.json:/opt/bitnami/apache/htdocs/gridadmin/env.json:Z
-    depends_on:
-      - logspout
     memswap_limit: 128m
     deploy:
       resources:

--- a/docker-compose/technical/docker-compose.technical.yml
+++ b/docker-compose/technical/docker-compose.technical.yml
@@ -8,6 +8,10 @@ services:
       - 15672:15672
       - 5672:5672
       - 15692:15692
+    depends_on:
+      logspout:
+        condition: "service_started"
+        required: false
     restart: unless-stopped
 
   postgres:

--- a/docker-compose/technical/docker-compose.technical.yml
+++ b/docker-compose/technical/docker-compose.technical.yml
@@ -8,8 +8,6 @@ services:
       - 15672:15672
       - 5672:5672
       - 15692:15692
-    depends_on:
-      - logspout
     restart: unless-stopped
 
   postgres:
@@ -75,6 +73,9 @@ services:
     restart: unless-stopped
 
   logstash:
+    profiles:
+      - all
+      - kibana
     image: docker.elastic.co/logstash/logstash:8.7.1
     volumes:
       - $PWD/../technical/pipelines.yml:/config/pipelines.yml:Z
@@ -85,10 +86,16 @@ services:
       - elasticsearch
 
   socat:
+    profiles:
+      - all
+      - kibana
     image: alpine/socat
     command: 'TCP-LISTEN:5000,reuseaddr,fork TCP:logstash:5000,forever,interval=5'
 
   logspout:
+    profiles:
+      - all
+      - kibana
     image: gliderlabs/logspout:v3.2.13
     command: 'tcp://socat:5000?filter.name=grid*'
     environment:


### PR DESCRIPTION
* Move logstash, socat, logspout to kibana profile. This avoids cluttering elastic search indices with filebeat-* indices when the study profile is started
* Use `required: false` introduced in docker compose 2.20.0 to keep the previous behavior even when logspout is in a different profile. To use `required: false`, `condition` is set to its default value `service_started`