### PR TITLE
docker compose, add restart: unless-stopped everywhere

### DIFF
--- a/docker-compose/docker-compose.base.yml
+++ b/docker-compose/docker-compose.base.yml
@@ -400,6 +400,7 @@ services:
       - CLIENT_SILENT_REDIRECT_URI_10=http://localhost:3004/silent-renew-callback
     depends_on:
       - logspout
+    restart: unless-stopped
 
   apps-metadata-server:
     profiles:
@@ -426,3 +427,4 @@ services:
       resources:
         limits:
           memory: 128m
+    restart: unless-stopped

--- a/docker-compose/dynamic-mapping/docker-compose.override.yml
+++ b/docker-compose/dynamic-mapping/docker-compose.override.yml
@@ -20,6 +20,7 @@ services:
       resources:
         limits:
           memory: 128m
+    restart: unless-stopped
 
   dynamic-mapping-server:
     profiles:

--- a/docker-compose/merging/docker-compose.override.yml
+++ b/docker-compose/merging/docker-compose.override.yml
@@ -49,6 +49,7 @@ services:
       resources:
         limits:
           memory: 384m
+    restart: unless-stopped
 
   balances-adjustment-server:
     profiles:
@@ -74,6 +75,7 @@ services:
       resources:
         limits:
           memory: 1g
+    restart: unless-stopped
 
   case-validation-server:
     profiles:
@@ -98,6 +100,7 @@ services:
       resources:
         limits:
           memory: 384m
+    restart: unless-stopped
 
   cgmes-boundary-server:
     profiles:
@@ -184,6 +187,7 @@ services:
       resources:
         limits:
           memory: 128m
+    restart: unless-stopped
 
   cgmes-boundary-import-job:
     profiles:

--- a/docker-compose/study/docker-compose.override.yml
+++ b/docker-compose/study/docker-compose.override.yml
@@ -259,6 +259,7 @@ services:
       resources:
         limits:
           memory: 128m
+    restart: unless-stopped
 
   security-analysis-server:
     profiles:
@@ -359,6 +360,7 @@ services:
       resources:
         limits:
           memory: 128m
+    restart: unless-stopped
 
   explore-server:
     profiles:
@@ -533,3 +535,4 @@ services:
       resources:
         limits:
           memory: 128m
+    restart: unless-stopped

--- a/docker-compose/technical/docker-compose.technical.yml
+++ b/docker-compose/technical/docker-compose.technical.yml
@@ -83,10 +83,12 @@ services:
       - LOGSPOUT=ignore
     depends_on:
       - elasticsearch
+    restart: unless-stopped
 
   socat:
     image: alpine/socat
     command: 'TCP-LISTEN:5000,reuseaddr,fork TCP:logstash:5000,forever,interval=5'
+    restart: unless-stopped
 
   logspout:
     image: gliderlabs/logspout:v3.2.13
@@ -99,6 +101,7 @@ services:
       - /var/run/docker.sock:/tmp/docker.sock:ro
     depends_on:
       - socat
+    restart: unless-stopped
 
   pgadmin:
     profiles:
@@ -112,6 +115,7 @@ services:
       - PGADMIN_DEFAULT_PASSWORD=admin
     volumes:
       - $PWD/../technical/servers_pgadmin.json:/pgadmin4/servers.json
+    restart: unless-stopped
 
   prometheus:
     profiles:


### PR DESCRIPTION
For some servers (mainly logspout), this is needed because logspout exits if socat has not started listening on its port and is never restarted. We have already "used restart: unless-stopped" in all other places to handle these ordering problems (e.g. any java server started before postgres is ready), so it's logical to use it for logspout.

For other servers that do not depend on any ordering of startup of the other services, it helps for other use cases, like when the pod is killed because of OOM, or even killed manually by us because that's a handy way to restart something. So this makes everything more coherent.