### PR TITLE
make 2 servers optional

### DIFF
--- a/k8s/resources/study/config/study-server-application.yml
+++ b/k8s/resources/study/config/study-server-application.yml
@@ -1,2 +1,14 @@
 non-evacuated-energy:
   default-provider: OpenLoadFlow
+
+# 2 servers are optional (not delivered in open-source)
+gridsuite:
+  services:
+    -
+      name: state-estimation-server
+      base-uri: http://state-estimation-server/
+      optional: true
+    -
+      name: shortcircuit-server
+      base-uri: http://shortcircuit-server/
+      optional: true

--- a/k8s/resources/study/config/study-server-application.yml
+++ b/k8s/resources/study/config/study-server-application.yml
@@ -1,14 +1,10 @@
 non-evacuated-energy:
   default-provider: OpenLoadFlow
 
-# 2 servers are optional (not delivered in open-source)
+# optional server (not delivered in open-source)
 gridsuite:
   services:
     -
       name: state-estimation-server
       base-uri: http://state-estimation-server/
-      optional: true
-    -
-      name: shortcircuit-server
-      base-uri: http://shortcircuit-server/
       optional: true


### PR DESCRIPTION
state-estimation-server and shortcircuit-server should not appear in GridStudy webapp when they are not delivered (cf open-source deployment)
**EDIT**; shortcircuit-server is delivered on azure/Demo ... then we cannot use the "optional" flag for it.