### PR TITLE
Remove obsolete .itools/tmp directory in dynamic-simulation-server

### DIFF
--- a/k8s/resources/study/dynamic-simulation-server-deployment.yaml
+++ b/k8s/resources/study/dynamic-simulation-server-deployment.yaml
@@ -28,8 +28,6 @@ spec:
               name: dynawo-config-configmap-volume
             - mountPath: /home/powsybl/.itools
               name: dynawo-itools-configmap-volume
-            - mountPath: /home/powsybl/.itools/tmp
-              name: itoolstmp-emptydir
       volumes:
         - name: dynamic-simulation-server-configmap-specific-volume
           configMap:
@@ -40,5 +38,3 @@ spec:
         - name: dynawo-itools-configmap-volume
           configMap:
             name: dynawo-itools-configmap
-        - name: itoolstmp-emptydir
-          emptyDir: { }


### PR DESCRIPTION
Remove temporary emptyDir /home/powsybl/.itools/tmp from https://github.com/gridsuite/deployment/pull/316