### PR TITLE
favorite countries metadata

### DIFF
--- a/docker-compose/apps-metadata.json
+++ b/docker-compose/apps-metadata.json
@@ -16,6 +16,8 @@
       "path" : "/studies/{elementUuid}"
     }
   ],
+  "favoriteCountries": ["DE", "BE", "ES", "FR", "IT", "LU", "GB", "CH"],
+  "defaultCountry": "FR",
   "predefinedEquipmentProperties" : {
     "substation" : {
       "region" : ["east", "south", "west", "north"],


### PR DESCRIPTION
Adds some default metadata for local development. relative to this development : 
https://github.com/gridsuite/commons-ui/pull/532

Technically those are RTE data but nothing secret (France as the main country and a few neighbouring countries as favorites) so this was approved by Jon.