### PR TITLE
Add a script to init the line catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,13 +21,14 @@ $ chmod 777 cases postgres elasticsearch init
 |---------------------------------------------------------------------------------------------------------------------------------|
 
 
-<a name="data_init"></a>All databases are created automatically at start as well as the necessary initial data loading (geographical, cgmes boundaries, tsos, ...).
+<a name="data_init"></a>When the postgres container is created, all databases are created automatically as well as the necessary initial data loading (geographical, cgmes boundaries, tsos, lines catalog...).
 
-To do this, you must copy the following files in the init directory :
+To do this, you must copy the following files in the init directory (_$GRIDSUITE_DATABASES/init_), **before** creating the postgres container:
 - [geo_data_substations.json](https://raw.githubusercontent.com/gridsuite/geo-data/main/src/test/resources/geo_data_substations.json)
 - [geo_data_lines.json](https://raw.githubusercontent.com/gridsuite/geo-data/main/src/test/resources/geo_data_lines.json)
 - [business_processes.json](https://raw.githubusercontent.com/gridsuite/cgmes-boundary-server/main/src/test/resources/business_processes.json)
 - [tsos.json](https://raw.githubusercontent.com/gridsuite/cgmes-boundary-server/main/src/test/resources/tsos.json)
+- [lines-catalog.json](https://raw.githubusercontent.com/gridsuite/network-modification-server/main/src/test/resources/lines-catalog.json)
 
 ### Clone deployment repository
 
@@ -64,11 +65,11 @@ $ cd docker-compose/dynamic-mapping
 $ docker compose up
 ```
 
-__Notes__ : When using docker-compose for deployment, your machine is accessible from the containers thought the ip address 172.17.0.1
+__Note__ : When using docker-compose for deployment, your machine is accessible from the containers thought the ip address 172.17.0.1
 
-__Notes__ : The containers are accessible from your machine thought the ip address `127.0.0.1` (localhost) or `172.17.0.1` and the corresponding port
+__Note__ : The containers are accessible from your machine thought the ip address `127.0.0.1` (localhost) or `172.17.0.1` and the corresponding port
 
-__Notes__ :
+__Note__ :
 These folders (other than `explicit-profiles`) act now like an alias to `docker compose --project-name grid<name> --profile <folder_name> ...`,
 with the difference that they have implicitly a profile active and will be considered like another project stack,
 so compose commands will not affect others folders state.
@@ -481,9 +482,10 @@ Alternatively, you can do this :
 
 With a terminal, go to the docker directory where you ran the `docker compose up -d` command.
 
-Make sure the `postgres`, `odre-server` and `geo-data-server` services are up with the `docker compose ps` command.
+Make sure the `postgres`, `odre-server`, `geo-data-server` and `network-modification-server` services are up with the `docker compose ps` command.
 ```bash
 $ docker compose exec postgres /init-geo-data.sh
+$ docker compose exec postgres /init-lines-catalog.sh
 $ docker compose exec postgres /init-merging-data.sh
 ```
 

--- a/docker-compose/study/.env
+++ b/docker-compose/study/.env
@@ -1,4 +1,5 @@
 PROJECT_DIR_NAME=study
+PROJECT_STUDY_DIR_NAME=study
 COMPOSE_PATH_SEPARATOR=:
 COMPOSE_PROJECT_NAME=gridstudy
 COMPOSE_FILE=docker-compose.override.yml:../docker-compose.base.yml:../merging/docker-compose.override.yml:../dynamic-mapping/docker-compose.override.yml:../technical/docker-compose.technical.yml

--- a/docker-compose/suite/.env
+++ b/docker-compose/suite/.env
@@ -1,4 +1,5 @@
 PROJECT_DIR_NAME=suite
+PROJECT_SUITE_DIR_NAME=suite
 COMPOSE_PATH_SEPARATOR=:
 COMPOSE_PROJECT_NAME=gridsuite
 COMPOSE_FILE=docker-compose.marker.yml:../docker-compose.base.yml:../study/docker-compose.override.yml:../merging/docker-compose.override.yml:../dynamic-mapping/docker-compose.override.yml:../technical/docker-compose.technical.yml

--- a/docker-compose/technical/docker-compose.technical.yml
+++ b/docker-compose/technical/docker-compose.technical.yml
@@ -45,6 +45,7 @@ services:
       - $PWD/../technical/init-databases.sh:/init-databases.sh:Z
       - $PWD/../technical/init-geo-data.sh:/init-geo-data.sh:Z
       - $PWD/../technical/init-merging-data.sh:/init-merging-data.sh:Z
+      - $PWD/../technical/init-lines-catalog.sh:/init-lines-catalog.sh:Z
     restart: unless-stopped
 
   postgres-exporter:

--- a/docker-compose/technical/init-databases.sh
+++ b/docker-compose/technical/init-databases.sh
@@ -3,8 +3,8 @@
 set -e
 
 /create-postgres-databases.sh &
-
 /init-geo-data.sh &
 /init-merging-data.sh &
+/init-lines-catalog.sh &
 
 exec docker-entrypoint.sh "$@"

--- a/docker-compose/technical/init-lines-catalog.sh
+++ b/docker-compose/technical/init-lines-catalog.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+set -e
+
+function init_lines_catalog()
+{
+  CATALOG_EXAMPLE=/init-data/lines-catalog.json
+  if [ -f $CATALOG_EXAMPLE ]; then
+      curl -X 'POST' -f -s -o /dev/null 'http://network-modification-server/v1/network-modifications/catalog/line_types'  -H "Content-Type: application/json" -H 'accept: application/json' --data @${CATALOG_EXAMPLE}
+  fi
+}
+
+if [ "$PROJECT_DIR_NAME" == "$PROJECT_STUDY_DIR_NAME" ] || [ "$PROJECT_DIR_NAME" == "$PROJECT_SUITE_DIR_NAME" ]
+then
+  until init_lines_catalog
+  do
+    echo "curl: network-modification-server is unavailable to initialize data - will retry later"
+    sleep 5
+  done
+fi

--- a/docker-compose/technical/init-lines-catalog.sh
+++ b/docker-compose/technical/init-lines-catalog.sh
@@ -4,9 +4,9 @@ set -e
 
 function init_lines_catalog()
 {
-  CATALOG_EXAMPLE=/init-data/lines-catalog.json
-  if [ -f $CATALOG_EXAMPLE ]; then
-      curl -X 'POST' -f -s -o /dev/null 'http://network-modification-server/v1/network-modifications/catalog/line_types'  -H "Content-Type: application/json" -H 'accept: application/json' --data @${CATALOG_EXAMPLE}
+  LINES_CATALOG=/init-data/lines-catalog.json
+  if [ -f $LINES_CATALOG ]; then
+      curl -X 'POST' -f -s -o /dev/null 'http://network-modification-server/v1/network-modifications/catalog/line_types' -H "Content-Type: application/json" -d "@${LINES_CATALOG}"
   fi
 }
 


### PR DESCRIPTION
Issue: I had to define PROJECT_STUDY_DIR_NAME=suite in study/.env to make it work in the case I dont use the explicit profiles.

How can we do differently ?