### PR TITLE
Change Xmx and forking for multithread AS

### DIFF
--- a/k8s/components/gridsuite/patches/deployments-springboot-size-xxxl-forking.yaml
+++ b/k8s/components/gridsuite/patches/deployments-springboot-size-xxxl-forking.yaml
@@ -1,0 +1,17 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: not-important
+spec:
+  template:
+    spec:
+      containers:
+        - name: main
+          env:
+          - name: JAVA_TOOL_OPTIONS
+            value: "-Xmx3072m"
+          resources:
+            requests:
+              memory: "5632m"
+            limits:
+              memory: "5632m"

--- a/k8s/resources/study/security-analysis-server-deployment.yaml
+++ b/k8s/resources/study/security-analysis-server-deployment.yaml
@@ -9,7 +9,7 @@ metadata:
     gridsuite.org/springboot-with-database: "true"
     gridsuite.org/springboot-with-rabbitmq: "true"
   annotations:
-    gridsuite.org/size: springboot-xxl-forking
+    gridsuite.org/size: springboot-xxxl-forking
 spec:
   selector:
     matchLabels:


### PR DESCRIPTION
Add a template for AS in multithread with Xmx=3072m and memory limit=5632m.
The memory limit is 5632m=Xmx+1024m (for the JVM)+1536m (for hades2 in multithread). It follows the previous sizing of memory limit = 1,27*Xmx+279m.
With 8 threads each, two parallel hades computation takes around 1g. The Xmx of 3g is well sized for 2 OLF in parallel with 8 threads each.