### PR TITLE
Change default config for security-analysis in local deployment

### DIFF
--- a/docker-compose/study/docker-compose.override.yml
+++ b/docker-compose/study/docker-compose.override.yml
@@ -299,15 +299,15 @@ services:
         condition: "service_started"
         required: false
     environment:
-      - JAVA_TOOL_OPTIONS=-Xmx768m #deployment: 1408m
+      - JAVA_TOOL_OPTIONS=-Xmx1408m #deployment: 3072m
     command: --server.port=80 --spring.config.additional-location=/config/
     sysctls:
       - net.ipv4.ip_unprivileged_port_start=0 # for docker < 20.03.0
-    memswap_limit: 1792m #deployment: 3072m
+    memswap_limit: 2048m #deployment: 5632m
     deploy:
       resources:
         limits:
-          memory: 1792m #deployment: 3072m
+          memory: 2048m #deployment: 5632m
 
   dynamic-simulation-server:
     profiles:

--- a/docker-compose/study/docker-compose.override.yml
+++ b/docker-compose/study/docker-compose.override.yml
@@ -299,15 +299,15 @@ services:
         condition: "service_started"
         required: false
     environment:
-      - JAVA_TOOL_OPTIONS=-Xmx1408m #deployment: 3072m
+      - JAVA_TOOL_OPTIONS=-Xmx1086m #deployment: 3072m
     command: --server.port=80 --spring.config.additional-location=/config/
     sysctls:
       - net.ipv4.ip_unprivileged_port_start=0 # for docker < 20.03.0
-    memswap_limit: 2048m #deployment: 5632m
+    memswap_limit: 1792m #deployment: 5632m
     deploy:
       resources:
         limits:
-          memory: 2048m #deployment: 5632m
+          memory: 1792m #deployment: 5632m
 
   dynamic-simulation-server:
     profiles:

--- a/k8s/live/azure-dev/kustomization.yaml
+++ b/k8s/live/azure-dev/kustomization.yaml
@@ -49,6 +49,10 @@ configMapGenerator:
     behavior: merge
     files:
       - config.yml=loadflow-server-config.yml
+  - name: security-analysis-server-itools-configmap
+    behavior: merge
+    files:
+      - config.yml=security-analysis-server-config.yml
 
 # Patch ingress host
 patches:

--- a/k8s/live/azure-dev/security-analysis-server-config.yml
+++ b/k8s/live/azure-dev/security-analysis-server-config.yml
@@ -15,4 +15,4 @@ computation-local:
   available-core: 2
 
 open-security-analysis-default-parameters:
-  threadCount: 4
+  threadCount: 8

--- a/k8s/resources/study/config/security-analysis-server-config.yml
+++ b/k8s/resources/study/config/security-analysis-server-config.yml
@@ -15,4 +15,4 @@ computation-local:
   available-core: 2
 
 open-security-analysis-default-parameters:
-  threadCount: 4
+  threadCount: 2


### PR DESCRIPTION
* Keep 8 threads for azure deployment of security-analysis
* Reduce to 2 threads the deployment of security-analysis in local to avoid using too much memory, adjust the Xmx and memory accordingly

This should fix the issue of Java heap space when running a security analysis locally for all kinds of studies