### PR TITLE
Stop minio when storag type=FS

### DIFF
--- a/docker-compose/technical/docker-compose.technical.yml
+++ b/docker-compose/technical/docker-compose.technical.yml
@@ -157,12 +157,14 @@ services:
     restart: unless-stopped
 
   s3-storage:
-    profiles:
-      - all
-      - s3
     image: minio/minio:RELEASE.2023-09-27T15-22-50Z
     # need to override entrypoint to create the bucket, is there a simpler way ?
-    entrypoint: sh
+    entrypoint:
+      - sh
+      - -c
+      - |
+        [ "$STORAGE_TYPE" = "S3" ] || exit 0
+        exec "$@"
     command: -c 'mkdir -p /data/bucket-gridsuite && /opt/bin/minio server /data --console-address ":9090"'
     ports:
      - "19000:9000"

--- a/docker-compose/technical/docker-compose.technical.yml
+++ b/docker-compose/technical/docker-compose.technical.yml
@@ -159,19 +159,15 @@ services:
   s3-storage:
     image: minio/minio:RELEASE.2023-09-27T15-22-50Z
     # need to override entrypoint to create the bucket, is there a simpler way ?
-    entrypoint:
-      - sh
-      - -c
-      - |
-        [ "$STORAGE_TYPE" = "S3" ] || exit 0
-        exec "$@"
-    command: -c 'mkdir -p /data/bucket-gridsuite && /opt/bin/minio server /data --console-address ":9090"'
+    entrypoint: sh
+    # We couldn't find yet another way to conditionnally start or not the minio container. Better solution appreciated.
+    command: -c '[ "$STORAGE_TYPE" = "FS" ] && exit 0; mkdir -p /data/bucket-gridsuite && /usr/bin/docker-entrypoint.sh server /data --console-address ":9090"'
     ports:
      - "19000:9000"
      - "19090:9090"
     volumes:
       - $GRIDSUITE_DATABASES/cases_v1/miniodata:/data:Z
-    restart: unless-stopped
+    restart: on-failure
 
   prometheus:
     profiles:

--- a/docker-compose/technical/docker-compose.technical.yml
+++ b/docker-compose/technical/docker-compose.technical.yml
@@ -160,8 +160,8 @@ services:
     image: minio/minio:RELEASE.2023-09-27T15-22-50Z
     # need to override entrypoint to create the bucket, is there a simpler way ?
     entrypoint: sh
-    # We couldn't find yet another way to conditionnally start or not the minio container. Better solution appreciated.
-    command: -c '[ "$STORAGE_TYPE" = "FS" ] && exit 0; mkdir -p /data/bucket-gridsuite && /usr/bin/docker-entrypoint.sh server /data --console-address ":9090"'
+    # We couldn't find yet another way to conditionnally start or not the minio container. Better solution  appreciated.
+    command: -c '[ "$STORAGE_TYPE" = "S3" ] || exit 0; mkdir -p /data/bucket-gridsuite && /usr/bin/docker-entrypoint.sh server /data --console-address ":9090"'
     ports:
      - "19000:9000"
      - "19090:9090"


### PR DESCRIPTION
Minio container is used only when STORAGE_TYPE=S3. The only solution we found yes is to check the env variable $STORAGE_TYPE in the command and to exit the cointainer when STORAGE_TYPE!=S3