### PR TITLE
CI .github/main.yml, use python 3.x instead of 3.7 to work on newer distros

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Set up python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.7'
+          python-version: '3.x'
 
       - name: Install python dependencies
         run: python -m pip install --upgrade pip pyyaml requests


### PR DESCRIPTION
The CI was working on ubuntu 22 but failing on ubuntu 24 because of
"The version '3.7' with architecture 'x64' was not found for Ubuntu 24.04."