### PR TITLE
Change user-admin-server and gateway sizes to XS

### DIFF
--- a/k8s/resources/common/gateway-deployment.yaml
+++ b/k8s/resources/common/gateway-deployment.yaml
@@ -7,7 +7,7 @@ metadata:
     version: "1"
     app.kubernetes.io/component: gridsuite-springboot
   annotations:
-    gridsuite.org/size: springboot-xxs
+    gridsuite.org/size: springboot-xs
 spec:
   selector:
     matchLabels:

--- a/k8s/resources/common/user-admin-server-deployment.yaml
+++ b/k8s/resources/common/user-admin-server-deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/component: gridsuite-springboot
     gridsuite.org/springboot-with-database: "true"
   annotations:
-    gridsuite.org/size: springboot-xxs
+    gridsuite.org/size: springboot-xs
 spec:
   selector:
     matchLabels:


### PR DESCRIPTION
After monitoring full GC of gateway and user-admin-server, we see that they are frequent and often >200ms. Given that we want to reduce latency on these central services, we increase Xmx to see if it improves performance.
From time to time, the gateway and user-admin-server are OOMKilled so we take a safety margin (again these deployments are central). 