### PR TITLE
Set maximum number of Tomcat threads to 20

### DIFF
--- a/k8s/resources/common/config/common-application.yml
+++ b/k8s/resources/common/config/common-application.yml
@@ -6,6 +6,12 @@ spring:
     username: ${RABBITMQ_USER:guest}
     password: ${RABBITMQ_PASSWORD:guest}
 
+#FIXME: To remove when powsybl-ws-commons 1.24.0 is released
+server:
+  tomcat:
+    threads:
+      max: 20
+
 powsybl-ws:
   environment:
 


### PR DESCRIPTION
Change the maximum number of Tomcat threads to 20.
This change is temporary waiting for the release of powsybl-ws-commons (https://github.com/powsybl/powsybl-ws-commons/pull/106) that should be upgraded on next powsybl upgrade.