### PR TITLE
Fix network-conversion-server configmap not accounted for in Kubernetes deployment

### DIFF
--- a/k8s/resources/common/network-conversion-server-deployment.yaml
+++ b/k8s/resources/common/network-conversion-server-deployment.yaml
@@ -25,7 +25,12 @@ spec:
         volumeMounts:
         - mountPath: /config/specific
           name: network-conversion-server-configmap-specific-volume
+        - mountPath: /home/powsybl/.itools
+          name: network-conversion-server-itools-configmap-volume
       volumes:
         - name: network-conversion-server-configmap-specific-volume
           configMap:
             name: network-conversion-server-configmap-specific
+        - name: network-conversion-server-itools-configmap-volume
+          configMap:
+            name: network-conversion-server-itools-configmap


### PR DESCRIPTION
Reverts https://github.com/gridsuite/deployment/pull/233 now that network-conversion-server-config contains data. 
After this change, the network-conversion-server-config is correctly taken into account in Kubernetes deployment.