### PR TITLE
Industrialization: add margins on memory limits

### DIFF
--- a/k8s/components/gridsuite/patches/deployments-springboot-size-l.yaml
+++ b/k8s/components/gridsuite/patches/deployments-springboot-size-l.yaml
@@ -12,6 +12,6 @@ spec:
             value: "-Xmx768m"
           resources:
             requests:
-              memory: "1.25Gi"
+              memory: "1.5Gi"
             limits:
-              memory: "1.25Gi"
+              memory: "1.5Gi"

--- a/k8s/components/gridsuite/patches/deployments-springboot-size-m.yaml
+++ b/k8s/components/gridsuite/patches/deployments-springboot-size-m.yaml
@@ -12,6 +12,6 @@ spec:
             value: "-Xmx576m"
           resources:
             requests:
-              memory: "1Gi"
+              memory: "1.25Gi"
             limits:
-              memory: "1Gi"
+              memory: "1.25Gi"

--- a/k8s/components/gridsuite/patches/deployments-springboot-size-s.yaml
+++ b/k8s/components/gridsuite/patches/deployments-springboot-size-s.yaml
@@ -12,6 +12,6 @@ spec:
             value: "-Xmx384m"
           resources:
             requests:
-              memory: "768Mi"
+              memory: "1Gi"
             limits:
-              memory: "768Mi"
+              memory: "1Gi"

--- a/k8s/components/gridsuite/patches/deployments-springboot-size-xl.yaml
+++ b/k8s/components/gridsuite/patches/deployments-springboot-size-xl.yaml
@@ -12,6 +12,6 @@ spec:
             value: "-Xmx1086m"
           resources:
             requests:
-              memory: "1664Mi"
+              memory: "2Gi"
             limits:
-              memory: "1664Mi"
+              memory: "2Gi"

--- a/k8s/components/gridsuite/patches/deployments-springboot-size-xs.yaml
+++ b/k8s/components/gridsuite/patches/deployments-springboot-size-xs.yaml
@@ -12,6 +12,6 @@ spec:
             value: "-Xmx186m"
           resources:
             requests:
-              memory: "512Mi"
+              memory: "768Mi"
             limits:
-              memory: "512Mi"
+              memory: "768Mi"

--- a/k8s/components/gridsuite/patches/deployments-springboot-size-xxl.yaml
+++ b/k8s/components/gridsuite/patches/deployments-springboot-size-xxl.yaml
@@ -12,6 +12,6 @@ spec:
             value: "-Xmx1408m"
           resources:
             requests:
-              memory: "2Gi"
+              memory: "2.5Gi"
             limits:
-              memory: "2Gi"
+              memory: "2.5Gi"

--- a/k8s/components/gridsuite/patches/deployments-springboot-size-xxs.yaml
+++ b/k8s/components/gridsuite/patches/deployments-springboot-size-xxs.yaml
@@ -9,7 +9,7 @@ spec:
         - name: main
           env:
           - name: JAVA_TOOL_OPTIONS
-            value: "-Xmx96m"
+            value: "-Xmx128m"
           resources:
             requests:
               memory: "512Mi"

--- a/k8s/components/gridsuite/patches/deployments-springboot-size-xxs.yaml
+++ b/k8s/components/gridsuite/patches/deployments-springboot-size-xxs.yaml
@@ -12,6 +12,6 @@ spec:
             value: "-Xmx96m"
           resources:
             requests:
-              memory: "384Mi"
+              memory: "512Mi"
             limits:
-              memory: "384Mi"
+              memory: "512Mi"


### PR DESCRIPTION
To improve robustness and prevent OOMKilled errors across our environments, I propose increasing the memory limits by 25%, rounding them up as we currently do. 
This should help us maintain pod memory usage around 85%, providing a reasonable safety margin for industrial operation.
I did not change forking sizing as we don't have issues with those for now.