### PR TITLE
Remove directory-server-native

### DIFF
--- a/docker-compose/study/docker-compose.study.yml
+++ b/docker-compose/study/docker-compose.study.yml
@@ -403,7 +403,7 @@ services:
         condition: "service_started"
         required: false
     environment:
-      - JAVA_TOOL_OPTIONS=-Xmx186m # not used by the native image
+      - JAVA_TOOL_OPTIONS=-Xmx186m
     command: --server.port=80 --spring.config.additional-location=/config/
     sysctls:
       - net.ipv4.ip_unprivileged_port_start=0 # for docker < 20.03.0

--- a/k8s/components/gridsuite/kustomization.yaml
+++ b/k8s/components/gridsuite/kustomization.yaml
@@ -79,11 +79,6 @@ patches:
     kind: Deployment
     labelSelector: app.kubernetes.io/component=gridsuite-springboot
     annotationSelector: gridsuite.org/cpu=cpu-xxl
-- path: patches/memory/deployments-springboot-memory-springnative-xs.yaml
-  target:
-    kind: Deployment
-    labelSelector: app.kubernetes.io/component=gridsuite-springboot
-    annotationSelector: gridsuite.org/memory=memory-springnative-xs
 - path: patches/memory/deployments-springboot-memory-xxs.yaml
   target:
     kind: Deployment

--- a/k8s/live/azure-integ/kustomization.yaml
+++ b/k8s/live/azure-integ/kustomization.yaml
@@ -78,7 +78,7 @@ images:
     digest: 1e516b408a7156aed3b70b3fa7d6860ed80445b858b4630364ea6c892e3d01da
   - name: docker.io/gridsuite/study-server
     digest: 8f4f7382e3ac9e07e562c4e3e8180841fe67a1f1c8fb7dac619dfc759c62bbcf
-  - name: docker.io/gridsuite/directory-server-native
+  - name: docker.io/gridsuite/directory-server
     digest: todo
   - name: docker.io/gridsuite/explore-server
     digest: todo

--- a/k8s/resources/study/directory-server-deployment.yaml
+++ b/k8s/resources/study/directory-server-deployment.yaml
@@ -11,7 +11,7 @@ metadata:
     gridsuite.org/springboot-with-elasticsearch: "true"
   annotations:
     gridsuite.org/cpu: cpu-s
-    gridsuite.org/memory: memory-springnative-xs
+    gridsuite.org/memory: memory-xs
 spec:
   selector:
     matchLabels:

--- a/k8s/resources/study/directory-server-deployment.yaml
+++ b/k8s/resources/study/directory-server-deployment.yaml
@@ -23,7 +23,7 @@ spec:
     spec:
       containers:
       - name: main
-        image: docker.io/gridsuite/directory-server-native:latest
+        image: docker.io/gridsuite/directory-server:latest
         volumeMounts:
         - mountPath: /config/specific
           name: directory-server-configmap-specific-volume


### PR DESCRIPTION
## PR Summary
<!-- Briefly summarize the changes: what it was before, what it is after, and any important notes for reviewers. -->
This repository was the only one in the Gridsuite ecosystem experimenting with Spring Native (GraalVM native image compilation). The work was initiated to explore potential RAM footprint reduction but has remained in an experimental state.

We are abandoning this initiative for the following reasons:

1. This repository is the only one carrying Spring Native configuration. Without broader adoption across the platform, maintaining this setup in isolation adds complexity with no ecosystem-wide benefit.
2. There has been no demand or initiative from the infrastructure team to leverage native images for reducing the memory footprint of our services. Without infra support and validation in production environments, the effort cannot deliver tangible results.
3. Spring Native expertise has not been disseminated across the team. The knowledge remains siloed, making long-term maintenance risky and unsustainable. Keeping this configuration without a shared understanding would create a maintenance burden with no clear ownership.
4. The development team has shown no traction toward adopting Spring Native more widely across Gridsuite services. Without collective buy-in, this remains a one-off experiment rather than a strategic direction.+
5. Each new Spring Boot major version brings breaking changes to the native image compilation pipeline (AOT processing, reachability metadata, GraalVM compatibility). Maintaining native support adds significant migration effort that is not justified by the gains, given that native images are not used in production and no team is actively pushing for their adoption.
6. Support for reachability metadata in https://github.com/oracle/graalvm-reachability-metadata is often late and missing some well known libraries.


