### PR TITLE
Add loadflow worker server for GridMonitor

### DIFF
--- a/docker-compose/docker-compose.base.yml
+++ b/docker-compose/docker-compose.base.yml
@@ -297,6 +297,7 @@ services:
       - dynamic-mapping
       - dynamic-simulation
       - import
+      - monitor
     image: gridsuite/loadflow-server:latest
     ports:
       - 5008:80

--- a/docker-compose/monitor/docker-compose.monitor.yml
+++ b/docker-compose/monitor/docker-compose.monitor.yml
@@ -52,7 +52,7 @@ services:
     volumes:
       - ../../k8s/resources/monitor/config/monitor-lf-worker-server-application.yml:/config/specific/application.yml:Z
       - ../../k8s/resources/common/config/common-application.yml:/config/common/application.yml:Z
-      - ../../k8s/resources/common/config/loadflow-server-config.yml:/home/powsybl/.itools/config.yml:Z
+      - ../../k8s/resources/common/config/monitor-lf-worker-server-config.yml:/home/powsybl/.itools/config.yml:Z
     restart: unless-stopped
     environment:
       - JAVA_TOOL_OPTIONS=-Xmx768m #deployment: 1408m

--- a/docker-compose/monitor/docker-compose.monitor.yml
+++ b/docker-compose/monitor/docker-compose.monitor.yml
@@ -51,8 +51,8 @@ services:
     image: gridsuite/monitor-worker-server:latest
     volumes:
       - ../../k8s/resources/monitor/config/monitor-lf-worker-server-application.yml:/config/specific/application.yml:Z
+      - ../../k8s/resources/monitor/config/monitor-lf-worker-server-config.yml:/home/powsybl/.itools/config.yml:Z
       - ../../k8s/resources/common/config/common-application.yml:/config/common/application.yml:Z
-      - ../../k8s/resources/common/config/monitor-lf-worker-server-config.yml:/home/powsybl/.itools/config.yml:Z
     restart: unless-stopped
     environment:
       - JAVA_TOOL_OPTIONS=-Xmx768m #deployment: 1408m

--- a/docker-compose/monitor/docker-compose.monitor.yml
+++ b/docker-compose/monitor/docker-compose.monitor.yml
@@ -43,3 +43,23 @@ services:
       resources:
         limits:
           memory: 1792m #deployment: 5632m
+
+  monitor-lf-worker-server:
+    profiles:
+      - all
+      - monitor
+    image: gridsuite/monitor-worker-server:latest
+    volumes:
+      - ../../k8s/resources/monitor/config/monitor-lf-worker-server-application.yml:/config/specific/application.yml:Z
+      - ../../k8s/resources/common/config/common-application.yml:/config/common/application.yml:Z
+    restart: unless-stopped
+    environment:
+      - JAVA_TOOL_OPTIONS=-Xmx1086m #deployment: 3072m
+    command: --server.port=80 --spring.config.additional-location=/config/
+    sysctls:
+      - net.ipv4.ip_unprivileged_port_start=0 # for docker < 20.03.0
+    memswap_limit: 1792m #deployment: 5632m
+    deploy:
+      resources:
+        limits:
+          memory: 1792m #deployment: 5632m

--- a/docker-compose/monitor/docker-compose.monitor.yml
+++ b/docker-compose/monitor/docker-compose.monitor.yml
@@ -52,14 +52,15 @@ services:
     volumes:
       - ../../k8s/resources/monitor/config/monitor-lf-worker-server-application.yml:/config/specific/application.yml:Z
       - ../../k8s/resources/common/config/common-application.yml:/config/common/application.yml:Z
+      - ../../k8s/resources/common/config/loadflow-server-config.yml:/home/powsybl/.itools/config.yml:Z
     restart: unless-stopped
     environment:
-      - JAVA_TOOL_OPTIONS=-Xmx1086m #deployment: 3072m
+      - JAVA_TOOL_OPTIONS=-Xmx768m #deployment: 1408m
     command: --server.port=80 --spring.config.additional-location=/config/
     sysctls:
       - net.ipv4.ip_unprivileged_port_start=0 # for docker < 20.03.0
-    memswap_limit: 1792m #deployment: 5632m
+    memswap_limit: 1792m #deployment: 3072m
     deploy:
       resources:
         limits:
-          memory: 1792m #deployment: 5632m
+          memory: 1792m #deployment: 3072m

--- a/docker-compose/study/docker-compose.study.yml
+++ b/docker-compose/study/docker-compose.study.yml
@@ -391,6 +391,7 @@ services:
       - study
       - study-light
       - dynamic-simulation
+      - monitor
     image: gridsuite/directory-server:latest
     ports:
       - 5026:80

--- a/k8s/resources/monitor/config/monitor-lf-worker-server-application.yml
+++ b/k8s/resources/monitor/config/monitor-lf-worker-server-application.yml
@@ -1,0 +1,2 @@
+worker:
+  process: loadflow

--- a/k8s/resources/monitor/config/monitor-lf-worker-server-config.yml
+++ b/k8s/resources/monitor/config/monitor-lf-worker-server-config.yml
@@ -1,0 +1,16 @@
+# Nb of LF concurrent processes - should be in-sync with loadflow.run.loadflowGroup queue concurrency
+computation-local:
+  available-core: 4
+
+load-flow-default-parameters:
+  voltageInitMode: DC_VALUES
+  phaseShifterRegulationOn: true
+  twtSplitShuntAdmittance: true
+  dcUseTransformerRatio: false
+  countriesToBalance:
+    - FR
+
+#TODO: remove writeReferenceTerminals parameter override when ReferenceTerminals extension is implemented
+open-loadflow-default-parameters:
+  writeReferenceTerminals: false
+  slackDistributionFailureBehavior : FAIL

--- a/k8s/resources/monitor/config/monitor-lf-worker-server-config.yml
+++ b/k8s/resources/monitor/config/monitor-lf-worker-server-config.yml
@@ -1,7 +1,3 @@
-# Nb of LF concurrent processes - should be in-sync with loadflow.run.loadflowGroup queue concurrency
-computation-local:
-  available-core: 4
-
 load-flow-default-parameters:
   voltageInitMode: DC_VALUES
   phaseShifterRegulationOn: true

--- a/k8s/resources/monitor/kustomization.yaml
+++ b/k8s/resources/monitor/kustomization.yaml
@@ -19,6 +19,6 @@ configMapGenerator:
   - name: monitor-sa-worker-server-itools-configmap
     files:
       - config.yml=config/monitor-sa-worker-server-config.yml
-  - name: monitor-sa-worker-server-configmap-specific
+  - name: monitor-lf-worker-server-configmap-specific
     files:
       - application.yml=config/monitor-lf-worker-server-application.yml

--- a/k8s/resources/monitor/kustomization.yaml
+++ b/k8s/resources/monitor/kustomization.yaml
@@ -22,3 +22,6 @@ configMapGenerator:
   - name: monitor-lf-worker-server-configmap-specific
     files:
       - application.yml=config/monitor-lf-worker-server-application.yml
+  - name: monitor-lf-worker-server-itools-configmap
+    files:
+      - config.yml=config/monitor-lf-worker-server-config.yml

--- a/k8s/resources/monitor/kustomization.yaml
+++ b/k8s/resources/monitor/kustomization.yaml
@@ -6,6 +6,8 @@ resources:
   - monitor-server-service.yaml
   - monitor-sa-worker-server-deployment.yaml
   - monitor-sa-worker-server-service.yaml
+  - monitor-lf-worker-server-deployment.yaml
+  - monitor-lf-worker-server-service.yaml
 
 configMapGenerator:
   - name: monitor-server-configmap-specific
@@ -17,3 +19,6 @@ configMapGenerator:
   - name: monitor-sa-worker-server-itools-configmap
     files:
       - config.yml=config/monitor-sa-worker-server-config.yml
+  - name: monitor-sa-worker-server-configmap-specific
+    files:
+      - application.yml=config/monitor-lf-worker-server-application.yml

--- a/k8s/resources/monitor/monitor-lf-worker-server-deployment.yaml
+++ b/k8s/resources/monitor/monitor-lf-worker-server-deployment.yaml
@@ -10,7 +10,7 @@ metadata:
     gridsuite.org/springboot-with-s3: "true"
   annotations:
     gridsuite.org/cpu: cpu-xl
-    gridsuite.org/memory: memory-xxl-forking
+    gridsuite.org/memory: memory-l-forking
 spec:
   selector:
     matchLabels:

--- a/k8s/resources/monitor/monitor-lf-worker-server-deployment.yaml
+++ b/k8s/resources/monitor/monitor-lf-worker-server-deployment.yaml
@@ -27,12 +27,7 @@ spec:
           volumeMounts:
             - mountPath: /config/specific
               name: monitor-lf-worker-server-configmap-specific-volume
-            - mountPath: /home/powsybl/.itools
-              name: monitor-lf-worker-server-itools-configmap-volume
       volumes:
         - name: monitor-lf-worker-server-configmap-specific-volume
           configMap:
             name: monitor-lf-worker-server-configmap-specific
-        - name: monitor-lf-worker-server-itools-configmap-volume
-          configMap:
-            name: monitor-lf-worker-server-itools-configmap

--- a/k8s/resources/monitor/monitor-lf-worker-server-deployment.yaml
+++ b/k8s/resources/monitor/monitor-lf-worker-server-deployment.yaml
@@ -9,8 +9,8 @@ metadata:
     gridsuite.org/springboot-with-rabbitmq: "true"
     gridsuite.org/springboot-with-s3: "true"
   annotations:
-    gridsuite.org/cpu: cpu-l
-    gridsuite.org/memory: memory-xl
+    gridsuite.org/cpu: cpu-xl
+    gridsuite.org/memory: memory-xxl-forking
 spec:
   selector:
     matchLabels:
@@ -26,7 +26,12 @@ spec:
           volumeMounts:
             - mountPath: /config/specific
               name: monitor-lf-worker-server-configmap-specific-volume
+            - mountPath: /home/powsybl/.itools
+              name: monitor-lf-worker-server-itools-configmap-volume
       volumes:
         - name: monitor-lf-worker-server-configmap-specific-volume
           configMap:
             name: monitor-lf-worker-server-configmap-specific
+        - name: monitor-lf-worker-server-itools-configmap-volume
+          configMap:
+            name: monitor-lf-worker-server-itools-configmap

--- a/k8s/resources/monitor/monitor-lf-worker-server-deployment.yaml
+++ b/k8s/resources/monitor/monitor-lf-worker-server-deployment.yaml
@@ -9,7 +9,7 @@ metadata:
     gridsuite.org/springboot-with-rabbitmq: "true"
     gridsuite.org/springboot-with-s3: "true"
   annotations:
-    gridsuite.org/cpu: cpu-xl
+    gridsuite.org/cpu: cpu-m
     gridsuite.org/memory: memory-l-forking
 spec:
   selector:

--- a/k8s/resources/monitor/monitor-lf-worker-server-deployment.yaml
+++ b/k8s/resources/monitor/monitor-lf-worker-server-deployment.yaml
@@ -1,0 +1,38 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: monitor-lf-worker-server
+  labels:
+    name: monitor-lf-worker-server
+    version: "1"
+    app.kubernetes.io/component: gridsuite-springboot
+    gridsuite.org/springboot-with-database: "true"
+    gridsuite.org/springboot-with-rabbitmq: "true"
+    gridsuite.org/springboot-with-s3: "true"
+  annotations:
+    gridsuite.org/cpu: cpu-l
+    gridsuite.org/memory: memory-xl
+spec:
+  selector:
+    matchLabels:
+      name: monitor-lf-worker-server
+  template:
+    metadata:
+      labels:
+        name: monitor-lf-worker-server
+    spec:
+      containers:
+        - name: main
+          image: docker.io/gridsuite/monitor-worker-server:latest
+          volumeMounts:
+            - mountPath: /config/specific
+              name: monitor-lf-worker-server-configmap-specific-volume
+            - mountPath: /home/powsybl/.itools
+              name: monitor-lf-worker-server-itools-configmap-volume
+      volumes:
+        - name: monitor-lf-worker-server-configmap-specific-volume
+          configMap:
+            name: monitor-lf-worker-server-configmap-specific
+        - name: monitor-lf-worker-server-itools-configmap-volume
+          configMap:
+            name: monitor-lf-worker-server-itools-configmap

--- a/k8s/resources/monitor/monitor-lf-worker-server-deployment.yaml
+++ b/k8s/resources/monitor/monitor-lf-worker-server-deployment.yaml
@@ -6,7 +6,6 @@ metadata:
     name: monitor-lf-worker-server
     version: "1"
     app.kubernetes.io/component: gridsuite-springboot
-    gridsuite.org/springboot-with-database: "true"
     gridsuite.org/springboot-with-rabbitmq: "true"
     gridsuite.org/springboot-with-s3: "true"
   annotations:

--- a/k8s/resources/monitor/monitor-lf-worker-server-service.yaml
+++ b/k8s/resources/monitor/monitor-lf-worker-server-service.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: monitor-lf-worker-server
+    app.kubernetes.io/component: gridsuite-springboot
+  name: monitor-lf-worker-server
+spec:
+  selector:
+    name: monitor-lf-worker-server


### PR DESCRIPTION
## PR Summary
<!-- Briefly summarize the changes: what it was before, what it is after, and any important notes for reviewers. -->

- Add `loadflow-server` to the monitor Docker Compose profiles
- Add loadflow-worker-server

