### PR TITLE
Fix gridmonitor app deployment on other platforms

### DIFF
--- a/k8s/live/azure-dev/gridmonitor-app-idpSettings.json
+++ b/k8s/live/azure-dev/gridmonitor-app-idpSettings.json
@@ -1,0 +1,8 @@
+{
+    "authority" : "https://login.microsoftonline.com/common/v2.0",
+    "client_id" : "590a2d0c-6fb7-4c2f-ac2d-c874fe98a88b",
+    "redirect_uri": "https://demo.gridsuite.org/gridmonitor/sign-in-callback",
+    "post_logout_redirect_uri" : "https://demo.gridsuite.org/gridmonitor/logout-callback",
+    "silent_redirect_uri" : "https://demo.gridsuite.org/gridmonitor/silent-renew-callback",
+    "scope" : "openid User.read profile"
+}

--- a/k8s/live/azure-dev/kustomization.yaml
+++ b/k8s/live/azure-dev/kustomization.yaml
@@ -25,6 +25,9 @@ configMapGenerator:
   - name: gridadmin-app-configmap
     files:
       - idpSettings.json=gridadmin-app-idpSettings.json
+  - name: gridmonitor-app-configmap
+    files:
+      - idpSettings.json=gridmonitor-app-idpSettings.json
   - name: apps-metadata-server-configmap
     behavior: merge
     files:

--- a/k8s/live/azure-integ/gridmonitor-app-idpSettings.json
+++ b/k8s/live/azure-integ/gridmonitor-app-idpSettings.json
@@ -1,0 +1,8 @@
+{
+    "authority" : "https://login.microsoftonline.com/common/v2.0",
+    "client_id" : "e85332cb-7898-4f2a-a2da-7963d168acee",
+    "redirect_uri": "https://gridsuite-ingress.francecentral.cloudapp.azure.com/gridmonitor/sign-in-callback",
+    "post_logout_redirect_uri" : "https://gridsuite-ingress.francecentral.cloudapp.azure.com/gridmonitor/logout-callback",
+    "silent_redirect_uri" : "https://gridsuite-ingress.francecentral.cloudapp.azure.com/gridmonitor/silent-renew-callback",
+    "scope" : "openid User.read profile"
+}

--- a/k8s/live/azure-integ/kustomization.yaml
+++ b/k8s/live/azure-integ/kustomization.yaml
@@ -24,6 +24,9 @@ configMapGenerator:
   - name: gridadmin-app-configmap
     files:
       - idpSettings.json=gridadmin-app-idpSettings.json
+  - name: gridmonitor-app-configmap
+    files:
+      - idpSettings.json=gridmonitor-app-idpSettings.json
   - name: common-application-configmap
     behavior: merge
     files:

--- a/k8s/live/local/gridmonitor-app-idpSettings.json
+++ b/k8s/live/local/gridmonitor-app-idpSettings.json
@@ -1,0 +1,8 @@
+{
+    "authority" : "http://<INGRESS_HOST>/oidc-mock-server/",
+    "client_id" : "gridmonitor-client",
+    "redirect_uri": "http://<INGRESS_HOST>/gridmonitor/sign-in-callback",
+    "post_logout_redirect_uri" : "http://<INGRESS_HOST>/gridmonitor/logout-callback",
+    "silent_redirect_uri" : "http://<INGRESS_HOST>/gridmonitor/silent-renew-callback",
+    "scope" : "openid"
+}

--- a/k8s/live/local/kustomization.yaml
+++ b/k8s/live/local/kustomization.yaml
@@ -66,6 +66,9 @@ configMapGenerator:
   - name: gridadmin-app-configmap
     files:
       - idpSettings.json=gridadmin-app-idpSettings.json
+  - name: gridmonitor-app-configmap
+    files:
+      - idpSettings.json=gridmonitor-app-idpSettings.json
   - name: common-application-configmap
     behavior: merge
     files:


### PR DESCRIPTION
## PR Summary
<!-- Briefly summarize the changes: what it was before, what it is after, and any important notes for reviewers. -->
There was a missing configmap for app deployment on azure-dev, integ and local platforms


