### PR TITLE
Size network-conversion-server to allow large network imports

### DIFF
--- a/docker-compose/docker-compose.base.yml
+++ b/docker-compose/docker-compose.base.yml
@@ -310,15 +310,15 @@ services:
         condition: "service_started"
         required: false
     environment:
-      - JAVA_TOOL_OPTIONS=-Xmx576m
+      - JAVA_TOOL_OPTIONS=-Xmx576m #deployment: 3072m for large networks
     command: --server.port=80 --spring.config.additional-location=/config/
     sysctls:
       - net.ipv4.ip_unprivileged_port_start=0 # for docker < 20.03.0
-    memswap_limit: 1g 
+    memswap_limit: 1g  #deployment: 4540m for large networks
     deploy:
       resources:
         limits:
-          memory: 1g 
+          memory: 1g  #deployment: 4540m for large networks
 
   loadflow-server:
     profiles:

--- a/k8s/resources/common/network-conversion-server-deployment.yaml
+++ b/k8s/resources/common/network-conversion-server-deployment.yaml
@@ -10,7 +10,7 @@ metadata:
     gridsuite.org/springboot-with-rabbitmq: "true"
     gridsuite.org/springboot-with-large-storage: "true"
     gridsuite.org/springboot-with-s3: "true"
-annotations:
+  annotations:
     gridsuite.org/cpu: cpu-xl
 spec:
   selector:

--- a/k8s/resources/common/network-conversion-server-deployment.yaml
+++ b/k8s/resources/common/network-conversion-server-deployment.yaml
@@ -10,9 +10,6 @@ metadata:
     gridsuite.org/springboot-with-rabbitmq: "true"
     gridsuite.org/springboot-with-large-storage: "true"
     gridsuite.org/springboot-with-s3: "true"
-  annotations:
-    gridsuite.org/cpu: cpu-xl
-    gridsuite.org/memory: memory-xxl
 spec:
   selector:
     matchLabels:
@@ -25,6 +22,16 @@ spec:
       containers:
       - name: main
         image: docker.io/powsybl/network-conversion-server:latest
+        env:
+            - name: JAVA_TOOL_OPTIONS
+              value: "-Xmx3072m"
+        resources:
+            requests:
+              cpu: "2500m"
+              memory: "4540Mi"
+            limits:
+              cpu: "5000m"
+              memory: "4540Mi"
         volumeMounts:
         - mountPath: /config/specific
           name: network-conversion-server-configmap-specific-volume

--- a/k8s/resources/common/network-conversion-server-deployment.yaml
+++ b/k8s/resources/common/network-conversion-server-deployment.yaml
@@ -10,6 +10,8 @@ metadata:
     gridsuite.org/springboot-with-rabbitmq: "true"
     gridsuite.org/springboot-with-large-storage: "true"
     gridsuite.org/springboot-with-s3: "true"
+annotations:
+    gridsuite.org/cpu: cpu-xl
 spec:
   selector:
     matchLabels:
@@ -27,10 +29,8 @@ spec:
               value: "-Xmx3072m"
         resources:
             requests:
-              cpu: "2500m"
               memory: "4540Mi"
             limits:
-              cpu: "5000m"
               memory: "4540Mi"
         volumeMounts:
         - mountPath: /config/specific


### PR DESCRIPTION
## PR Summary
<!-- Briefly summarize the changes: what it was before, what it is after, and any important notes for reviewers. -->
Upgrade memory configuration to allow large network imports without OOM errors
Add docker-compose comment to inform dev that conf must be upgraded if using large networks


