### PR TITLE
Fix max file size on demo

### DIFF
--- a/k8s/live/azure/config/apps-metadata.json
+++ b/k8s/live/azure/config/apps-metadata.json
@@ -1,0 +1,61 @@
+[{
+  "name" : "Study",
+  "url"  : "/gridstudy",
+  "appColor" : "#0CA789",
+  "hiddenInAppsMenu" : true,
+  "hiddenUserInformation": true,
+  "resources" : [
+    {
+      "types" : ["STUDY"],
+      "path" : "/studies/{elementUuid}"
+    }
+  ],
+  "predefinedEquipmentProperties" : {
+    "substation" : {
+      "Demo" : ["demo1", "demo2"]
+    }
+  },
+  "defaultParametersValues": {
+  },
+  "localStorageTtlDays": 7,
+  "baseMapOptions" : [
+    {
+      "id": "mapbox",
+      "label": "Mapbox"
+    },
+    {
+      "id": "carto",
+      "label": "Carto"
+    },
+    {
+      "id": "cartonolabel",
+      "label": "CartoNoLabel"
+    },
+    {
+      "id": "etalab",
+      "label": "Etalab"
+    }
+  ]
+},
+{
+  "name" : "Explore",
+  "url"  : "/gridexplore",
+  "appColor" : "#33AFED",
+  "hiddenInAppsMenu" : false,
+  "hiddenUserInformation": true,
+  "maxFileSizeInMb": 1
+},
+{
+  "name" : "Dynamic Mapping",
+  "url"  : "/griddyna",
+  "appColor" : "#FFC11B",
+  "hiddenInAppsMenu" : false,
+  "hiddenUserInformation": true
+},
+{
+  "name" : "Admin",
+  "url"  : "/gridadmin",
+  "appColor" : "#FD3745",
+  "hiddenInAppsMenu" : true,
+  "hiddenUserInformation": true
+}]

--- a/k8s/live/azure/kustomization.yaml
+++ b/k8s/live/azure/kustomization.yaml
@@ -31,6 +31,7 @@ configMapGenerator:
   - name: apps-metadata-server-configmap
     behavior: merge
     files:
+      - config/apps-metadata.json
       - openid-configuration
       - keys
   - name: apps-metadata-server-httpdconf-configmap


### PR DESCRIPTION
## PR Summary
<!-- Briefly summarize the changes: what it was before, what it is after, and any important notes for reviewers. -->
On demo the maximum file size to display the error:
 ```Le fichier sélectionné dépasse la taille limite (100 Mo). Veuillez compresser ce fichier au format zip, gzip ou bzip2 puis réessayez de l'importer à nouveau.``` instead of trying to upload it is set to 100MB by default. 
I updated the explore metadata to set it to 1. That way, we do not have the error from the server but from the front directly instead. It makes it clearer from a demo user perspective.


