### PR TITLE
fix bitnami -> dhi migration, docker.io is signficant for downstream kustomize

### DIFF
--- a/k8s/resources/common/apps-metadata-server-deployment.yaml
+++ b/k8s/resources/common/apps-metadata-server-deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
         - name: main
-          image: gridsuite/httpd:1.0.0@sha256:e054963bc0bdb0df484ad59a40072f29b3ff921a9887aa041f005c87e5ba2890
+          image: docker.io/gridsuite/httpd:1.0.0@sha256:e054963bc0bdb0df484ad59a40072f29b3ff921a9887aa041f005c87e5ba2890
           volumeMounts:
             - mountPath: /usr/local/apache2/htdocs/
               name: apps-metadata-server-configmap-volume

--- a/k8s/resources/common/default-backend-deployment.yaml
+++ b/k8s/resources/common/default-backend-deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
         - name: main
-          image: gridsuite/httpd:1.0.0@sha256:e054963bc0bdb0df484ad59a40072f29b3ff921a9887aa041f005c87e5ba2890
+          image: docker.io/gridsuite/httpd:1.0.0@sha256:e054963bc0bdb0df484ad59a40072f29b3ff921a9887aa041f005c87e5ba2890
           volumeMounts:
             - mountPath: /usr/local/apache2/htdocs/
               name: default-backend-htdocs-configmap-volume


### PR DESCRIPTION
Without it, it doesn't match and the image stays the same, not picked up by our newName/newTag kustomization

## PR Summary
<!-- Briefly summarize the changes: what it was before, what it is after, and any important notes for reviewers. -->



