### PR TITLE
Fix memory tuning for network-conversion-server docker compose container

### DIFF
--- a/docker-compose/docker-compose.base.yml
+++ b/docker-compose/docker-compose.base.yml
@@ -310,15 +310,15 @@ services:
         condition: "service_started"
         required: false
     environment:
-      - JAVA_TOOL_OPTIONS=-Xmx576m
+      - JAVA_TOOL_OPTIONS=-Xmx768m
     command: --server.port=80 --spring.config.additional-location=/config/
     sysctls:
       - net.ipv4.ip_unprivileged_port_start=0 # for docker < 20.03.0
-    memswap_limit: 1g 
+    memswap_limit: 1280m 
     deploy:
       resources:
         limits:
-          memory: 1g 
+          memory: 1280m 
 
   loadflow-server:
     profiles:


### PR DESCRIPTION
## PR Summary
Increase memory to 1280m and Xmx 768m for large RTE networks



